### PR TITLE
Fix clang-tidy-diff when no files in the repo have changed

### DIFF
--- a/ClangTidy.cmake
+++ b/ClangTidy.cmake
@@ -268,7 +268,8 @@ function(swift_setup_clang_tidy)
           ${${PROJECT_NAME}_CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml
           `git ls-files ${srcs}`
         DIFF_COMMAND
-          ${${PROJECT_NAME}_CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml
+        git diff --diff-filter=ACMRTUXB --quiet -- ${srcs} ||
+        ${${PROJECT_NAME}_CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml
           `git diff --diff-filter=ACMRTUXB --name-only master -- ${srcs}`
         )
   endif()


### PR DESCRIPTION
The clang-tidy-diff command runs clang-tidy and passes only the files in the repository which have changed. If nothing in the repo has changed clang-tidy ends up throwing an error. The PR adds a check to the command so that clang-tidy doesn't even run if there is nothing to do