### PR TITLE
Specify header file name for non-standard installs

### DIFF
--- a/FindGnss-converters.cmake
+++ b/FindGnss-converters.cmake
@@ -2,5 +2,6 @@ include("GenericFindDependency")
 GenericFindDependency(
     TARGET gnss_converters
     SOURCE_DIR "gnss-converters/c"
+    SYSTEM_HEADER_FILE "gnss-converters/nmea.h"
     SYSTEM_INCLUDES
     )

--- a/FindRtcm.cmake
+++ b/FindRtcm.cmake
@@ -2,5 +2,6 @@ include("GenericFindDependency")
 GenericFindDependency(
     TARGET rtcm
     SOURCE_DIR "c"
+    SYSTEM_HEADER_FILE "rtcm3/bits.h"
     SYSTEM_INCLUDES
     )

--- a/FindSwiftnav.cmake
+++ b/FindSwiftnav.cmake
@@ -1,5 +1,6 @@
 include("GenericFindDependency")
 GenericFindDependency(
     TARGET swiftnav
+    SYSTEM_HEADER_FILE "swiftnav/bits.h"
     SYSTEM_INCLUDES
     )


### PR DESCRIPTION
Some package header files can't be found automatically because they are installed to non-standard locations. By default GenericFindDependencies will search for a system header file called "lib${TARGET}/${TARGET}.h", for example the module FindSwiftnav (libswiftnav) will try to find "libswiftnav/swiftnav.h". Some packages install using a different naming scheme, libswiftnav installs "swiftnav/bits.h" (among others). This PR specifies different header file names for those packages so they can be found properly.