### PR TITLE
Custom command line arguments to clang-tidy

### DIFF
--- a/ClangTidy.cmake
+++ b/ClangTidy.cmake
@@ -163,7 +163,7 @@ endmacro()
 function(swift_setup_clang_tidy)
   set(argOption "REQUIRED")
   set(argSingle "SCRIPT")
-  set(argMulti "CLANG_TIDY_NAMES" "TARGETS" "PATTERNS")
+  set(argMulti "CLANG_TIDY_NAMES" "TARGETS" "PATTERNS" "EXTRA_ARGS")
 
   cmake_parse_arguments(x "${argOption}" "${argSingle}" "${argMulti}" ${ARGN})
 
@@ -262,14 +262,15 @@ function(swift_setup_clang_tidy)
   if(NOT srcs)
     early_exit(WARNING "Couldn't find any source/header files to tidy in ${PROJECT_NAME}")
   else()
+    message(WARNING "$$$$ ${x_EXTRA_ARGS}")
     create_targets(
         TOP_LEVEL ${top_level_project}
         ALL_COMMAND
-          ${${PROJECT_NAME}_CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml
+        ${${PROJECT_NAME}_CLANG_TIDY} ${x_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml
           `git ls-files ${srcs}`
         DIFF_COMMAND
         git diff --diff-filter=ACMRTUXB --quiet -- ${srcs} ||
-        ${${PROJECT_NAME}_CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml
+        ${${PROJECT_NAME}_CLANG_TIDY} ${x_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml
           `git diff --diff-filter=ACMRTUXB --name-only master -- ${srcs}`
         )
   endif()

--- a/ClangTidy.cmake
+++ b/ClangTidy.cmake
@@ -54,6 +54,16 @@
 # This function must be called with one of the above options, or it must be able to
 # find a custom script in the file system otherwise it will throw an error.
 #
+# The option EXTRA_ARGS may be used to pass command line options directly to the
+# clang-tidy command. This can be useful or even required when a compiler other
+# than clang is used to configure the project. clang-tidy will use the compile_commands.json
+# database to work out how to analyse files, but some GNU options are not understood.
+#
+# swift_setup_clang_tidy(EXTRA_ARGS '-extra-arg=-Wno-unknown-warning-option')
+#
+# will disable a clang-tidy error when it encounters a compiler warning switch it
+# doesn't support, such as -Wno-psabi (GNU does understand this one)
+#
 # All commands are run from ${CMAKE_CURRENT_SOURCE_DIR}. It is highly recommended
 # that this module only be included from the top level CMakeLists.txt of a project,
 # using it from a subdirectory may not work as expected.


### PR DESCRIPTION
Allow a project to pass command line options to clang-tidy. Useful in `starling` so it can disable certain compiler warning options that clang tools doesn't understand when `starling` itself is compiled using the GNU compiler