### PR TITLE
Add clang-tidy-[all/diff]-check targets

### DIFF
--- a/ClangTidy.cmake
+++ b/ClangTidy.cmake
@@ -117,6 +117,16 @@ function(create_targets)
         COMMAND ${x_DIFF_COMMAND}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         )
+    add_custom_target(clang-tidy-all-check
+        COMMAND test ! -f fixes.yaml
+        DEPENDS clang-tidy-all
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+    add_custom_target(clang-tidy-diff-check
+        COMMAND test ! -f fixes.yaml
+        DEPENDS clang-tidy-diff
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
   endif()
 endfunction()
 


### PR DESCRIPTION
Adds targets to check whether clang-tidy found any problems, similar to clang-format checks in https://github.com/swift-nav/cmake/pull/15