### PR TITLE
Added ability to run code coverage when unit test fails and support t…

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -86,6 +86,7 @@ if (NOT LLVM_COV_PATH)
     endif()
     find_program(LLVM_COV_PATH ${LLVM_COV_NAME})
 endif()
+find_program(GCOV_PATH gcov)
 find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
 
@@ -301,11 +302,12 @@ function(target_code_coverage TARGET_NAME)
         add_custom_target(
           ccov-${TARGET_NAME}
           COMMAND ${LCOV_PATH} --directory ${CMAKE_BINARY_DIR} --zerocounters
-          COMMAND $<TARGET_FILE:${TARGET_NAME}>
+          COMMAND $<TARGET_FILE:${TARGET_NAME}> || true
           COMMAND ${LCOV_PATH}
                   --directory ${CMAKE_BINARY_DIR}
                   --capture
                   --output-file ${COVERAGE_INFO}
+                  $<$<BOOL:${GCOV_PATH}>:--gcov-tool=${GCOV_PATH}>
           COMMAND ${EXCLUDE_COMMAND}
           COMMAND ${GENHTML_PATH} -o
                   ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/${TARGET_NAME}


### PR DESCRIPTION
There are two major changes introduced here.

1. Originally, any code coverage target whose underlying target ran and returned a status error code of anything other than zero, the code coverage target wouldn't try and produce a report. By introducing the ` || true` entry, we've disregarded the error code and continued along with reporting the test coverage anyways. This would need to be looked and approved by someone with better knowledge of the system then myself as this might break the desired behaviour of the build system.

2. Because in my setup I've got multiple versions of GCC running (open in my systems directory and an a number in `/opt/gcc/*`, I need a way to choose which `gcov` program to use as it needs to be bound to the correct `gcc` version for code coverage to work. This can be done by explicitly passing the `gcov` version to `lcov` command. Existing users shouldn't be affected as cmake will pickup the `gcov` within the system's `$PATH` and pass it explicitly to the `lcov` command, and if open isn't found, it just doesn't inform `lcov`.

Users can work with non system compilers via the following example cmake command:

```
cmake \
  -DCMAKE_PREFIX_PATH:PATH=/opt/gcc/7.4.0 \
  -DCMAKE_C_COMPILER:PATH=/opt/gcc/7.4.0/bin/gcc \
  -DCMAKE_CXX_COMPILER:PATH=/opt/gcc/7.4.0/bin/g++ \
  ...
```