### PR TITLE
Fixed GenericFindDependency when targets use generator expressions in include directories

### DIFF
--- a/GenericFindDependency.cmake
+++ b/GenericFindDependency.cmake
@@ -269,7 +269,7 @@ function(mark_target_as_system_includes TARGET)
   if(directories)
     message(STATUS "Marking ${x_TARGET} include directories as system")
     set_target_properties(${x_TARGET} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
-    target_include_directories(${x_TARGET} SYSTEM INTERFACE ${directories})
+    target_include_directories(${x_TARGET} SYSTEM INTERFACE "${directories}")
   endif()
 endfunction()
 


### PR DESCRIPTION
There was a very very subtle bug that exists within `GenericFindDependency.cmake` when calling it with the `SYSTEM_INCLUDES` option. In a scenario when you request to find GoogleTest, it goes through the `GenericFindDependency.cmake` and hits the function `mark_target_as_system_includes`. When it does this, it attempts to transfer all the elements from the target's `INTERFACE_INCLUDE_DIRECTORIES` and append them onto the `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` property using the following code:

```
    target_include_directories(${x_TARGET} SYSTEM INTERFACE ${directories})
```

Where `directories` contains the value of what was in `INTERFACE_INCLUDE_DIRECTORIES`. The problem arises when `INTERFACE_INCLUDE_DIRECTORIES` holds this valid value:

`
$<BUILD_INTERFACE:/home/rodrigor/Repositories/libpal_cpp/third_party/googletest/googletest/include;/home/rodrigor/Repositories/libpal_cpp/third_party/googletest/googletest>;$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
`

Notice that within the generator expression there is a semi-colon. Without the fix (adding the quotations around `${directories}`, cmake will assume the user has entered the following entries independently:

* `$<BUILD_INTERFACE:/home/rodrigor/Repositories/libpal_cpp/third_party/googletest/googletest/include`
* `/home/rodrigor/Repositories/libpal_cpp/third_party/googletest/googletest>`
* `$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>`

Which is invalid expression, which somehow cmake accepts and interprets in a strange way. Which led cmake to execute the follow command to compile a file:

`
cd /home/rodrigor/Repositories/libpal_cpp/build/gcc-7.3.0/debug/test && /opt/gcc/7.4.0/bin/g++   -I/home/rodrigor/Repositories/libpal_cpp/include -isystem /home/rodrigor/Repositories/libpal_cpp/home/rodrigor/Repositories/libpal_cpp/third_party/googletest/googletest/include -isystem /home/rodrigor/Repositories/libpal_cpp/third_party/googletest/googletest  -g   -fprofile-arcs -ftest-coverage -o CMakeFiles/test-pal++.dir/test_file_device.cc.o -c /home/rodrigor/Repositories/libpal_cpp/test/test_file_device.cc
` 

Notice the directory `home/rodrigor/Repositories/libpal_cpp/home/rodrigor/Repositories/libpal_cpp/third_party/googletest/googletest/include`.

By adding the quotation marks, it should append the entire content onto the list property, but because the way cmake handles lists, it just works.