### PR TITLE
Fixes issue between clang format and clang tidy where they share a function name

### DIFF
--- a/ClangFormat.cmake
+++ b/ClangFormat.cmake
@@ -76,7 +76,7 @@
 #
 
 # Helper function to actually create the targets, not to be used outside this file
-function(create_targets)
+function(create_clang_format_targets)
   set(argOption "")
   set(argSingle "TOP_LEVEL")
   set(argMulti "ALL_COMMAND" "DIFF_COMMAND")
@@ -168,7 +168,7 @@ function(swift_setup_clang_format)
   if(x_SCRIPT)
     if(EXISTS ${x_SCRIPT})
       message(STATUS "Initialising clang format targets for ${PROJECT_NAME} using existing script in ${x_SCRIPT}")
-      create_targets(
+      create_clang_format_targets(
           TOP_LEVEL ${top_level_project}
           ALL_COMMAND ${x_SCRIPT} all
           DIFF_COMMAND ${x_SCRIPT} diff
@@ -186,7 +186,7 @@ function(swift_setup_clang_format)
     if(EXISTS ${script})
       # Found a custom formatting script
       message(STATUS "Initialising clang format target for ${PROJECT_NAME} using existing script in ${script}")
-      create_targets(
+      create_clang_format_targets(
           TOP_LEVEL ${top_level_project}
           ALL_COMMAND ${script} all
           DIFF_COMMAND ${script} diff
@@ -228,7 +228,7 @@ function(swift_setup_clang_format)
     set(patterns '*.[ch]' '*.cpp' '*.cc' '*.hpp')
   endif()
 
-  create_targets(
+  create_clang_format_targets(
       TOP_LEVEL ${top_level_project}
       ALL_COMMAND git ls-files ${patterns} | xargs ${${PROJECT_NAME}_CLANG_FORMAT} -i
       DIFF_COMMAND git diff --diff-filter=ACMRTUXB --name-only master -- ${patterns} | xargs ${${PROJECT_NAME}_CLANG_FORMAT} -i

--- a/ClangTidy.cmake
+++ b/ClangTidy.cmake
@@ -84,7 +84,7 @@
 #
 
 # Helper function to actually create the targets, not to be used outside this file
-function(create_targets)
+function(create_clang_tidy_targets)
   set(argOption "")
   set(argSingle "TOP_LEVEL")
   set(argMulti "ALL_COMMAND" "DIFF_COMMAND")
@@ -218,7 +218,7 @@ function(swift_setup_clang_tidy)
   if(x_SCRIPT)
     if(EXISTS ${x_SCRIPT})
       message(STATUS "Initialising clang tidy targets for ${PROJECT_NAME} using existing script in ${x_SCRIPT}")
-      create_targets(
+      create_clang_tidy_targets(
           TOP_LEVEL ${top_level_project}
           ALL_COMMAND ${x_SCRIPT} all
           DIFF_COMMAND ${x_SCRIPT} diff
@@ -234,7 +234,7 @@ function(swift_setup_clang_tidy)
   foreach(script ${custom_scripts})
     if(EXISTS ${script})
       message(STATUS "Initialising clang tidy target for ${PROJECT_NAME} using existing script in ${script}")
-      create_targets(
+      create_clang_tidy_targets(
           TOP_LEVEL ${top_level_project}
           ALL_COMMAND ${script} all
           DIFF_COMMAND ${script} diff
@@ -282,7 +282,7 @@ function(swift_setup_clang_tidy)
   if(NOT srcs)
     early_exit(WARNING "Couldn't find any source/header files to tidy in ${PROJECT_NAME}")
   else()
-    create_targets(
+    create_clang_tidy_targets(
         TOP_LEVEL ${top_level_project}
         ALL_COMMAND
         ${${PROJECT_NAME}_CLANG_TIDY} ${x_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} --export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/fixes.yaml


### PR DESCRIPTION
This is another interesting subtle bug with cmake common. If you run the following command within the repository:

```
$ grep -Ehr -o '\s*function\s*\(\s*(\w+)' . | tr -d ' ' | sort | uniq -d
```

You will get a single result, `function(create_targets`. The command really just tries to list all the functions within the repository with the same name. This is important because I ran into an issue where I included both `ClangFormat.cmake`  and `ClangTidy.cmake` (in that order), but when I called `swift_setup_clang_format`, it created a number of tidy targets.

The reason for that issue was because `create_format` from `ClangFormat` would be overwritten by that create from `ClangTidy` and `swift_setup_clang_format` would call the `create_function`.

Did some reading and unfortunately there is no "nice" way of dealing with this. There is no policy to prevent overriding and no way to namespace the function name yet (https://gitlab.kitware.com/cmake/cmake/issues/17361). Best we can do it make sure that when we name a function, we follow the same principles as declaring C language functions and make them extraordinarily long and specific to the use case (this is me just making fun of C).