### PR TITLE
updated incorrect implementation of  FindPal++.cmake

### DIFF
--- a/FindPal++.cmake
+++ b/FindPal++.cmake
@@ -2,5 +2,6 @@ include("GenericFindDependency")
 option(pal++_ENABLE_TESTS "" OFF)
 GenericFindDependency(
     TARGET pal++
+    SOURCE_DIR libpal_cpp
     SYSTEM_INCLUDES
 )


### PR DESCRIPTION
Fixed minor issue when using cmake in starling since target doesn't match repo name.