### PR TITLE
Disable compiled OTL in starling by default [STAR-936]

### DIFF
--- a/FindStarling.cmake
+++ b/FindStarling.cmake
@@ -1,6 +1,7 @@
 include("GenericFindDependency")
 option(starling_ENABLE_TESTS "" OFF)
 option(starling_ENABLE_EXAMPLES "" OFF)
+option(starling_ENABLE_COMPILED_OTL "" OFF)
 GenericFindDependency(
     TARGET starling
     SYSTEM_HEADER_FILE "starling/starling.h"


### PR DESCRIPTION
This will reduce the size of the compiled `pvt-engine` target for users of the starling repo