### PR TITLE
Print out the commit and path for each source submodule that has been included in the build.

### DIFF
--- a/GenericFindDependency.cmake
+++ b/GenericFindDependency.cmake
@@ -69,7 +69,7 @@ function(search_dependency_source)
 
   foreach(P ${x_SOURCE_SEARCH_PATHS})
     if(EXISTS "${P}/CMakeLists.txt")
-      message(STATUS "******************* Found ${x_TARGET} source code in ${P}")
+      message(STATUS "Found ${x_TARGET} source code in ${P}")
       # Function arguments are automatically parsed out in to numbered variables
       # ARG#, and a complete argument list is stored in ARGN. Variables are passed
       # down the function call stack until they are overwritten. This allows a 
@@ -120,7 +120,6 @@ function(search_dependency_source)
         OUTPUT_STRIP_TRAILING_WHITESPACE
         )
       file(WRITE ${CMAKE_BINARY_DIR}/submodule-checks/${x_TARGET}.used "${GIT_COMMIT} ${P}\n")
-      message("########### wrote file ${CMAKE_BINARY_DIR}/submodule-checks/${x_TARGET}.used")
   
       if(NOT TARGET ${x_TARGET})
         message(WARNING "Source code in ${P} did not declare target ${x_TARGET} as was expected")

--- a/GenericFindDependency.cmake
+++ b/GenericFindDependency.cmake
@@ -111,7 +111,14 @@ function(search_dependency_source)
         unset(ARGV${i})
       endforeach()
       unset(ARGN)
+
       add_subdirectory(${P})
+      execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${P}
+        OUTPUT_VARIABLE GIT_COMMIT
+        )
+      file(WRITE ${CMAKE_BINARY_DIR}/submodule-checks/${x_TARGET}.used "${GIT_COMMIT} ${P}\n")
   
       if(NOT TARGET ${x_TARGET})
         message(WARNING "Source code in ${P} did not declare target ${x_TARGET} as was expected")

--- a/GenericFindDependency.cmake
+++ b/GenericFindDependency.cmake
@@ -69,7 +69,7 @@ function(search_dependency_source)
 
   foreach(P ${x_SOURCE_SEARCH_PATHS})
     if(EXISTS "${P}/CMakeLists.txt")
-      message(STATUS "Found ${x_TARGET} source code in ${P}")
+      message(STATUS "******************* Found ${x_TARGET} source code in ${P}")
       # Function arguments are automatically parsed out in to numbered variables
       # ARG#, and a complete argument list is stored in ARGN. Variables are passed
       # down the function call stack until they are overwritten. This allows a 

--- a/GenericFindDependency.cmake
+++ b/GenericFindDependency.cmake
@@ -117,8 +117,10 @@ function(search_dependency_source)
         COMMAND git rev-parse HEAD
         WORKING_DIRECTORY ${P}
         OUTPUT_VARIABLE GIT_COMMIT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
         )
       file(WRITE ${CMAKE_BINARY_DIR}/submodule-checks/${x_TARGET}.used "${GIT_COMMIT} ${P}\n")
+      message("########### wrote file ${CMAKE_BINARY_DIR}/submodule-checks/${x_TARGET}.used")
   
       if(NOT TARGET ${x_TARGET})
         message(WARNING "Source code in ${P} did not declare target ${x_TARGET} as was expected")


### PR DESCRIPTION
This is for ORI-834; I finally am building the machinery to check for consistency between our multiple copies of submodules.  There will be some scripts in orion that consume this output.
cc: @benjamin0 @mfine 