### PR TITLE
ESD-1647 initial implementation for a common doxygen documentation

### DIFF
--- a/DoxygenTargets.cmake
+++ b/DoxygenTargets.cmake
@@ -1,0 +1,48 @@
+function(swift_add_doxygen target)
+  find_package(Doxygen)
+
+  if(NOT DOXYGEN_FOUND)
+    message(WARNING "Unable to generate doxygen documentation for target \"${target}\" due to missing doxygen package")
+    return()
+  endif()
+
+  set(argOptions)
+  set(argSingleArguments CONFIGURE_FILE OUTPUT_DIRECTORY)
+  set(argMultiArguments SOURCE_DIRECTORIES)
+
+  cmake_parse_arguments(x "${argOptions}" "${argSingleArguments}" "${argMultiArguments}" ${ARGN})
+
+  if(x_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "swift_add_doxygen unparsed arguments - ${x_UNPARSED_ARGUMENTS}")
+  endif()
+
+  set(DOXYGEN_CONFIGURE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+  set(DOXYGEN_SOURCE_DIRECTORIES ${PROJECT_SOURCE_DIR})
+  set(DOXYGEN_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+  if(x_CONFIGURE_FILE)
+    set(DOXYGEN_CONFIGURE_FILE ${x_CONFIGURE_FILE})
+  endif()
+
+  if(x_SOURCE_DIRECTORIES)
+    set(DOXYGEN_SOURCE_DIRECTORIES ${x_SOURCE_DIRECTORIES})
+  endif()
+
+  if(x_OUTPUT_DIRECTORY)
+    set(DOXYGEN_OUTPUT_DIRECTORY ${x_OUTPUT_DIRECTORY})
+  endif()
+
+  string(REPLACE ";" "\" \"" DOXYGEN_SOURCE_DIRECTORIES "${DOXYGEN_SOURCE_DIRECTORIES}")
+
+  configure_file(${DOXYGEN_CONFIGURE_FILE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+
+  add_custom_target(${target}
+    COMMAND
+      ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    DEPENDS
+      ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    COMMENT
+      "Generating doxygen documentation output to \"${DOXYGEN_OUTPUT_DIRECTORY}\""
+  )
+
+endfunction()

--- a/DoxygenTargets.cmake
+++ b/DoxygenTargets.cmake
@@ -1,3 +1,55 @@
+#
+# OVERVIEW
+#
+# Provides functions that help generate Doxygen documentation for your project.
+#
+# The following functions are exposed for users to use:
+#
+#   swift_add_doxygen(target
+#     [CONFIGURE_FILE file]
+#     [OUTPUT_DIRECTORY directory]
+#     [SOURCE_DIRECTORIES directories...]
+#   )
+#
+# GENERATING DOCUMENTATION
+#
+# In order to create a cmake target that generates doxygen documentation, simply
+# invoke the "swift_add_doxygen" function with a desired name for your target.
+# The function offer the following options:
+#
+#   CONFIGURE_FILE: specify a Doxygen configuration file here, if one isn't
+#   provided, the default values will be ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in.
+#   The function will run the configuration file through cmake's "configure_file"
+#   command, so any cmake variables can be injected into the file. There are a
+#   few special variables available for use outside what is already available
+#   within the user's scope.
+#
+#     DOXYGEN_CONFIGURE_FILE: path specified within the CONFIGURE_FILE option
+#     DOXYGEN_OUTPUT_DIRECTORY: path specified within the OUTPUT_DIRECTORY option
+#     DOXYGEN_SOURCE_DIRECTORIES: paths specified within the SOURCE_DIRECTORIES option
+#
+#   Please note that whenever you wish to use the above variables within the
+#   Doxygen configuration file, make sure they are surrounded by quotes, so for
+#   example to specify the Doxygen value INPUT, you should do the following:
+#
+#     INPUT = "@DOXYGEN_SOURCE_DIRECTORIES@"
+#
+#   You could also use the ${VARIABLE} as well to specify variables, but would
+#   suggest you use @VARIABLE@.
+#
+#   OUTPUT_DIRECTORY: specify the location where doxygen outputs are to be
+#   generated. This variable will be exposed as DOXYGEN_OUTPUT_DIRECTORY and
+#   should be assigned to the doxygen configuration file's OUTPUT_DIRECTORY
+#   value for it to be useful. Default value is set to
+#   "${CMAKE_CURRENT_BINARY_DIR}".
+#
+#   SOURCE_DIRECTORIES: specifies the directories which doxygen will look
+#   through to extract the documentation from. This variable will be exposed
+#   as DOXYGEN_SOURCE_DIRECTORIES and should be assigned to the doxygen
+#   configuration file's INPUT variable for it to be useful. Default value is
+#   set to "${CMAKE_CURRENT_SOURCE_DIR}".
+#
+
 function(swift_add_doxygen target)
   find_package(Doxygen)
 
@@ -17,19 +69,19 @@ function(swift_add_doxygen target)
   endif()
 
   set(DOXYGEN_CONFIGURE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
-  set(DOXYGEN_SOURCE_DIRECTORIES ${PROJECT_SOURCE_DIR})
   set(DOXYGEN_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  set(DOXYGEN_SOURCE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
 
   if(x_CONFIGURE_FILE)
     set(DOXYGEN_CONFIGURE_FILE ${x_CONFIGURE_FILE})
   endif()
 
-  if(x_SOURCE_DIRECTORIES)
-    set(DOXYGEN_SOURCE_DIRECTORIES ${x_SOURCE_DIRECTORIES})
-  endif()
-
   if(x_OUTPUT_DIRECTORY)
     set(DOXYGEN_OUTPUT_DIRECTORY ${x_OUTPUT_DIRECTORY})
+  endif()
+
+  if(x_SOURCE_DIRECTORIES)
+    set(DOXYGEN_SOURCE_DIRECTORIES ${x_SOURCE_DIRECTORIES})
   endif()
 
   string(REPLACE ";" "\" \"" DOXYGEN_SOURCE_DIRECTORIES "${DOXYGEN_SOURCE_DIRECTORIES}")


### PR DESCRIPTION
jira: https://swift-nav.atlassian.net/browse/ESD-1647
usage: https://github.com/swift-nav/libpal_cpp/pull/33

This I'm hoping this will provide developers the ability to easily create doxygen documentation for their project. The documentation within the code should provide everything that is needed to understand how to use it easily.

**NOTE**: cmake 3.9+ offers a similar function (https://cmake.org/cmake/help/v3.9/module/FindDoxygen.html#command:doxygen_add_docs), the implementation is quite different, so please have a look at the link and have a think about the best approach, personally I prefer the PRs implementation. Also note that we have no standard Swift Navigation version of cmake, last time i checked, we were constrained down to using version 3.6 because of the work being done with the Android Studio IDE.

