### PR TITLE
Fix cross compiling system includes

### DIFF
--- a/GenericFindDependency.cmake
+++ b/GenericFindDependency.cmake
@@ -347,9 +347,7 @@ function(GenericFindDependency)
   # Final validation that the target was properly created from some source
   if(TARGET ${x_TARGET})
     if(x_SYSTEM_INCLUDES)
-      if(NOT CMAKE_CROSSCOMPILING OR THIRD_PARTY_INCLUDES_AS_SYSTEM)
-        mark_target_as_system_includes(${x_TARGET})
-      endif()
+      mark_target_as_system_includes(${x_TARGET})
     endif()
   else()
     # Target not found in any location


### PR DESCRIPTION
Not sure why this check was here in the first place, it effectively disables marking third party dependencies as system includes when cross compiling. It needs to go to get the step swiftlets build working