### PR TITLE
Add boost-math as interface

### DIFF
--- a/FindBoost-Math.cmake
+++ b/FindBoost-Math.cmake
@@ -1,0 +1,8 @@
+if(TARGET boost-math)
+  return()
+endif()
+
+add_library(boost-math INTERFACE)
+
+target_include_directories(boost-math SYSTEM INTERFACE
+      ${PROJECT_SOURCE_DIR}/third_party/boost-math/include/)


### PR DESCRIPTION
Boost Math is a sub-library from Boost. Most (if not all) of the functional part is in header files. This PR adds a CMake find script to add this library as interface (header files only).