### PR TITLE
Standardize system include targets

### DIFF
--- a/FindBoost-Math.cmake
+++ b/FindBoost-Math.cmake
@@ -4,5 +4,10 @@ endif()
 
 add_library(boost-math INTERFACE)
 
-target_include_directories(boost-math SYSTEM INTERFACE
+if (DEFINED THIRD_PARTY_INCLUDES_AS_SYSTEM AND NOT THIRD_PARTY_INCLUDES_AS_SYSTEM)
+  target_include_directories(boost-math INTERFACE
       ${PROJECT_SOURCE_DIR}/third_party/boost-math/include/)
+else()
+  target_include_directories(boost-math SYSTEM INTERFACE
+      ${PROJECT_SOURCE_DIR}/third_party/boost-math/include/)
+endif()

--- a/FindEigen.cmake
+++ b/FindEigen.cmake
@@ -4,16 +4,11 @@ endif()
 
 add_library(eigen INTERFACE)
 
-# Include Eigen library as system headers to suppress warnings when not
-# cross-compiling. GNU ARM toolchain wraps system headers with `extern "C"`,
-# causing errors, so in this case Eigen must be #included using
-# `#pragma GCC system_header` in the source.
-# See https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html
-if (NOT CMAKE_CROSSCOMPILING OR THIRD_PARTY_INCLUDES_AS_SYSTEM)
-  target_include_directories(eigen SYSTEM INTERFACE
+if (DEFINED THIRD_PARTY_INCLUDES_AS_SYSTEM AND NOT THIRD_PARTY_INCLUDES_AS_SYSTEM)
+  target_include_directories(eigen INTERFACE
       ${PROJECT_SOURCE_DIR}/third_party/eigen/)
 else()
-  target_include_directories(eigen INTERFACE
+  target_include_directories(eigen SYSTEM INTERFACE
       ${PROJECT_SOURCE_DIR}/third_party/eigen/)
 endif()
 

--- a/FindGFlags.cmake
+++ b/FindGFlags.cmake
@@ -1,19 +1,6 @@
 include("GenericFindDependency")
 GenericFindDependency(
-    TARGET gflags
-    SOURCE_DIR "googleflags"
-    )
-
-if(NOT CMAKE_CROSSCOMPILING OR THIRD_PARTY_INCLUDES_AS_SYSTEM)
-  # Change all of GoogleFlags's include directories to be system includes, to avoid
-  # compiler errors. The generalised version of this in GenericFindDependency won't
-  # work here because we are dealing with an aliased target
-  get_target_property(_aliased gflags ALIASED_TARGET)
-  if(_aliased)
-    get_target_property(gflags_include_directories ${_aliased} INTERFACE_INCLUDE_DIRECTORIES)
-    if(gflags_include_directories)
-      set_target_properties(${_aliased} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
-      target_include_directories(${_aliased} SYSTEM INTERFACE ${gflags_include_directories})
-    endif()
-  endif()
-endif()
+  TARGET gflags
+  SOURCE_DIR "googleflags"
+  SYSTEM_INCLUDES
+)

--- a/FindGnss-converters.cmake
+++ b/FindGnss-converters.cmake
@@ -4,5 +4,4 @@ GenericFindDependency(
     TARGET gnss_converters
     SOURCE_DIR "gnss-converters/c"
     SYSTEM_HEADER_FILE "gnss-converters/nmea.h"
-    SYSTEM_INCLUDES
     )

--- a/FindGoogletest.cmake
+++ b/FindGoogletest.cmake
@@ -1,7 +1,7 @@
 include("GenericFindDependency")
 GenericFindDependency(
     TARGET gtest
+    ADDITIONAL_TARGETS gmock
     SOURCE_DIR "googletest"
     SYSTEM_INCLUDES
-    )
-mark_target_as_system_includes(gmock)
+)

--- a/FindIxcom.cmake
+++ b/FindIxcom.cmake
@@ -3,5 +3,4 @@ option(libixcom_ENABLE_TESTS "" OFF)
 GenericFindDependency(
     TARGET ixcom
     SOURCE_DIR "c"
-    SYSTEM_INCLUDES
     )

--- a/FindOrion-Proto.cmake
+++ b/FindOrion-Proto.cmake
@@ -2,5 +2,4 @@ include("GenericFindDependency")
 GenericFindDependency(
     TARGET orion-proto
     SOURCE_DIR "orion_proto"
-    SYSTEM_INCLUDES
     )

--- a/FindPal++.cmake
+++ b/FindPal++.cmake
@@ -3,5 +3,4 @@ option(pal++_ENABLE_TESTS "" OFF)
 GenericFindDependency(
     TARGET pal++
     SOURCE_DIR libpal_cpp
-    SYSTEM_INCLUDES
 )

--- a/FindPal.cmake
+++ b/FindPal.cmake
@@ -3,5 +3,4 @@ option(pal_ENABLE_TESTS "" OFF)
 option(pal_ENABLE_EXAMPLES "" OFF)
 GenericFindDependency(
   TARGET pal
-  SYSTEM_INCLUDES
   )

--- a/FindPal.cmake
+++ b/FindPal.cmake
@@ -3,4 +3,4 @@ option(pal_ENABLE_TESTS "" OFF)
 option(pal_ENABLE_EXAMPLES "" OFF)
 GenericFindDependency(
   TARGET pal
-  )
+)

--- a/FindRapidCheck.cmake
+++ b/FindRapidCheck.cmake
@@ -4,27 +4,9 @@ include("GenericFindDependency")
 set(RC_ENABLE_GTEST ON CACHE BOOL "" FORCE)
 
 GenericFindDependency(
-    TARGET rapidcheck
-    )
-
-# Change all of rapidcheck's include directories to be system includes, to avoid
-# compiler errors. The generalised version in GenericFindDependency isn't suitable
-# in this instance.
-get_target_property(rapidcheck_interface_includes rapidcheck INTERFACE_INCLUDE_DIRECTORIES)
-if(rapidcheck_interface_includes)
-  set_target_properties(rapidcheck PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
-  target_include_directories(rapidcheck SYSTEM INTERFACE ${rapidcheck_interface_includes})
-else()
-  message(WARNING "No include directories in rapidcheck, this seems wrong")
-endif()
-unset(rapidcheck_interface_includes)
-
-get_target_property(rapidcheck_gtest_interface_includes rapidcheck_gtest INTERFACE_INCLUDE_DIRECTORIES)
-if(rapidcheck_gtest_interface_includes)
-  set_target_properties(rapidcheck_gtest PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
-  target_include_directories(rapidcheck_gtest SYSTEM INTERFACE ${rapidcheck_gtest_interface_includes})
-else()
-  message(WARNING "No include directories in rapidcheck_gtest, this seems wrong")
-endif()
-unset(rapidcheck_gtest_interface_includes)
+  TARGET rapidcheck
+  ADDITIONAL_TARGETS
+    rapidcheck_gtest
+  SYSTEM_INCLUDES
+)
 

--- a/FindRtcm.cmake
+++ b/FindRtcm.cmake
@@ -4,5 +4,4 @@ GenericFindDependency(
     TARGET rtcm
     SOURCE_DIR "c"
     SYSTEM_HEADER_FILE "rtcm3/bits.h"
-    SYSTEM_INCLUDES
     )

--- a/FindSbp.cmake
+++ b/FindSbp.cmake
@@ -4,5 +4,4 @@ option(libsbp_ENABLE_DOCS "" OFF)
 GenericFindDependency(
     TARGET sbp
     SOURCE_DIR "c"
-    SYSTEM_INCLUDES
     )

--- a/FindSettings.cmake
+++ b/FindSettings.cmake
@@ -2,5 +2,4 @@ include("GenericFindDependency")
 option(libsettings_ENABLE_TESTS "" OFF)
 GenericFindDependency(
     TARGET settings
-    SYSTEM_INCLUDES
     )

--- a/FindStarling.cmake
+++ b/FindStarling.cmake
@@ -1,15 +1,18 @@
 include("GenericFindDependency")
-option(starling_ENABLE_TESTS "" OFF)
-option(starling_ENABLE_EXAMPLES "" OFF)
-GenericFindDependency(
-    TARGET pvt-runner-lib
-    SOURCE_DIR starling
-    SYSTEM_HEADER_FILE "pvt_driver/runner/pvt_runner.h"
-    SYSTEM_INCLUDES
-)
 
-mark_target_as_system_includes(sensorfusion)
-mark_target_as_system_includes(pvt_driver)
-mark_target_as_system_includes(pvt-engine)
-mark_target_as_system_includes(pvt-common)
-mark_target_as_system_includes(starling-util)
+option(starling_ENABLE_TESTS "" OFF)
+option(starling_ENABLE_TEST_LIBS "" OFF)
+option(starling_ENABLE_EXAMPLES "" OFF)
+
+GenericFindDependency(
+  TARGET pvt-runner-lib
+  ADDITIONAL_TARGETS
+    sensorfusion
+    pvt_driver
+    pvt-engine
+    pvt-common
+    starling-util
+  SOURCE_DIR starling
+  SYSTEM_HEADER_FILE "pvt_driver/runner/pvt_runner.h"
+  SYSTEM_INCLUDES
+)

--- a/FindStarling.cmake
+++ b/FindStarling.cmake
@@ -14,5 +14,4 @@ GenericFindDependency(
     starling-util
   SOURCE_DIR starling
   SYSTEM_HEADER_FILE "pvt_driver/runner/pvt_runner.h"
-  SYSTEM_INCLUDES
 )

--- a/FindSwiftlets.cmake
+++ b/FindSwiftlets.cmake
@@ -3,5 +3,4 @@ option(swiftlets_ENABLE_TESTS "" OFF)
 GenericFindDependency(
     TARGET swiftlets
     SOURCE_DIR swiftlets
-    SYSTEM_INCLUDES
 )

--- a/FindSwiftnav.cmake
+++ b/FindSwiftnav.cmake
@@ -3,5 +3,4 @@ option(libswiftnav_ENABLE_TESTS "" OFF)
 GenericFindDependency(
     TARGET swiftnav
     SYSTEM_HEADER_FILE "swiftnav/bits.h"
-    SYSTEM_INCLUDES
     )

--- a/FindUbx.cmake
+++ b/FindUbx.cmake
@@ -3,5 +3,4 @@ option(libubx_ENABLE_TESTS "" OFF)
 GenericFindDependency(
     TARGET ubx
     SOURCE_DIR "c"
-    SYSTEM_INCLUDES
     )

--- a/FindVariant.cmake
+++ b/FindVariant.cmake
@@ -1,4 +1,5 @@
 include("GenericFindDependency")
 GenericFindDependency(
     TARGET variant
-    )
+    SYSTEM_INCLUDES
+)


### PR DESCRIPTION
**Background**

This PR works towards our Platform OKR (https://swift-nav.atlassian.net/wiki/spaces/ENG/pages/804816541/Platform+OKRs+Q3+2020) where we try and avoid using `THIRD_PARTY_INCLUDE` to mask our issues with submodules.

When calling `find_package(...)` to include a submodule project, we've by default made it so that all submodule projects are treated as foreign code, this is done by doing some cmake magic where we convert all C++ header include `-I` flags to `-isystem`. This is harmless in terms of generated code, but it does differ in terms of reporting warnings. Warnings are reported when using `-I` but not when using `-isystem`, so any issues in submodules are ignored which is problematic for a multitude of reasons:

* compiler warnings are ignored for submodules (problem if customer toolchain warning flags are ignored)
* static analysis is bounded to only the current project

There is an oddity in this logic as well that when cross compiling it no longer considers it "system" targets because of the bug in the toolchain used for `starling`'s `Build for Yocto` Jenkins stage, so I'd like to fix that by simply fixing the starling build script.

**Changes**

The changes that I'm introducing makes it clearer what the expected behaviour is. Any `Find*.cmake` script that calls `GenericFindDependency` and has `SYSTEM_INCLUDES` is by default treated as foreign libraries (system headers) which we have little influence over, so things like `eigen`, `variant`, `gtest`, etc fall under this category. If users don't specify `SYSTEM_INCLUDES` it is assumed to be within our control, so they are local headers by default. We can override this behaviour by  passing the `THIRD_PARTY_INCLUDES_AS_SYSTEM`, a `true` value will set everything to system header, a value of `false` will set everything to local.

Below is a list of all the third party projects which we consider SYSTEM (outside our control) vs LOCAL (within our control).

*SYSTEM*
*  Benchmark
*  Boost-Math
*  Check
*  Eigen
*  FastCSV
*  GFlags
*  GmockGlobal
*  GoogleTest
*  Json
*  Nanopb
*  Nlopt
*  Optional
*  Protobuf
*  RapidCheck
*  Variant
*  Yaml-Cpp

*LOCAL*
*  gnss-converters
*  Ixcom
*  Orion-Proto
*  Pal++
*  Pal
*  Rtcm
*  Sbp
*  Settings
*  Starling
*  Swiftlets
*  Swiftnav
*  Ubx

**PR depends on the following to be merged**
* https://github.com/swift-nav/variant/pull/2
* https://github.com/swift-nav/libpal_cpp/pull/120

**Changes tested on a number of down stream PRs**
* https://github.com/swift-nav/starling/pull/3655
* https://github.com/swift-nav/swiftlets/pull/653
* https://github.com/swift-nav/orion-engine/pull/1464
* https://github.com/swift-nav/orion_proto/pull/244
* https://github.com/swift-nav/piksi_apps/pull/635

**NOTE**: the PR failures above are due to `clang-format` errors (a false positive result because it uses `git diff` to identify format error, but the hacks in place modify the source code to reflect a uniform cmake/variant/libpal++ repo update across the organization).