### PR TITLE
[ESD-1864] Deprecate libpal++ repository

### DIFF
--- a/FindPal++.cmake
+++ b/FindPal++.cmake
@@ -1,6 +1,0 @@
-include("GenericFindDependency")
-option(pal++_ENABLE_TESTS "" OFF)
-GenericFindDependency(
-    TARGET pal++
-    SOURCE_DIR libpal_cpp
-)

--- a/FindPal.cmake
+++ b/FindPal.cmake
@@ -3,4 +3,5 @@ option(pal_ENABLE_TESTS "" OFF)
 option(pal_ENABLE_EXAMPLES "" OFF)
 GenericFindDependency(
   TARGET pal
+  ADDITIONAL_TARGETS pal++
 )


### PR DESCRIPTION
https://swift-nav.atlassian.net/wiki/spaces/~61688916/pages/1038549305/Design+snippet+-+libpal+tidy+up

Remove `FindPal++.cmake`, the target `libpal++` now exists in the main libpal repository