### PR TITLE
clang-format-diff improvements

### DIFF
--- a/ClangFormat.cmake
+++ b/ClangFormat.cmake
@@ -231,6 +231,7 @@ function(swift_setup_clang_format)
   create_clang_format_targets(
       TOP_LEVEL ${top_level_project}
       ALL_COMMAND git ls-files ${patterns} | xargs ${${PROJECT_NAME}_CLANG_FORMAT} -i
-      DIFF_COMMAND git diff --diff-filter=ACMRTUXB --name-only master -- ${patterns} | xargs ${${PROJECT_NAME}_CLANG_FORMAT} -i
+      DIFF_COMMAND git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ HEAD -- ${patterns}
+                   | xargs -t ${${PROJECT_NAME}_CLANG_FORMAT} -i
   )
 endfunction()


### PR DESCRIPTION
I had issues running `make clang-format-diff` in the gnss-converters repository because the root CMakeLists.txt isn't located at the repository root. This PR adds the absolute path to the diff paths.

Previously, we were also comparing to `master` explicitly. This PR changes that to `HEAD` instead, which makes more sense if running this e.g. on release branches which may have diverged from `master`.