### PR TITLE
clang-format-diff: compare to most recent tag on current branch

### DIFF
--- a/ClangFormat.cmake
+++ b/ClangFormat.cmake
@@ -231,7 +231,8 @@ function(swift_setup_clang_format)
   create_clang_format_targets(
       TOP_LEVEL ${top_level_project}
       ALL_COMMAND git ls-files ${patterns} | xargs ${${PROJECT_NAME}_CLANG_FORMAT} -i
-      DIFF_COMMAND git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ HEAD -- ${patterns}
-                   | xargs -t ${${PROJECT_NAME}_CLANG_FORMAT} -i
+      DIFF_COMMAND git describe --tags --abbrev=0 --always
+                   | xargs -I % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- ${patterns}
+                   | xargs ${${PROJECT_NAME}_CLANG_FORMAT} -i
   )
 endfunction()


### PR DESCRIPTION
This PR changes the diff target to the most recent tag on the current branch. Triggered by the discussion in https://snav.slack.com/archives/CD7HYKMV1/p1608278435480700