### PR TITLE
[ESD-1931] Remove no strict aliasing from common compile flags

### DIFF
--- a/CompileOptions.cmake
+++ b/CompileOptions.cmake
@@ -154,7 +154,6 @@ function(swift_set_compile_options)
         -Wunused-variable
         -Wvolatile-register-var
         -Wwrite-strings
-        -fno-strict-aliasing
     )
 
     if(x_REMOVE)


### PR DESCRIPTION
HITL has been failing in piksi recently on a stack usage check. This flag is the root cause of increased stack usage in the piksi main thread down to only 12 bytes free. 

I'm not entirely sure the original source of this flag but as the updates go through I'll find the target which was using it originally and add it back in as a special option. It wasn't previously applied to either pvt-engine (the target which ultimately caused the increased usage)