### PR TITLE
[ESD-1991] Default to C11

### DIFF
--- a/LanguageStandards.cmake
+++ b/LanguageStandards.cmake
@@ -33,7 +33,7 @@ function(swift_set_language_standards)
     cmake_parse_arguments(x "${argOption}" "${argSingle}" "${argMulti}" ${ARGN})
 
     if(NOT x_C)
-        set(x_C 99)
+        set(x_C 11)
     endif()
 
     if(NOT x_CXX)


### PR DESCRIPTION
Use C11 by default rather than C99. For the moment compiler extensions need to be left on due to the outstanding issue in libsbp. They can be turned off in the future but for the moment aren't actually causing any problems with any compiler in use.