### PR TITLE
SV4-144 update googleflags

### DIFF
--- a/FindGFlags.cmake
+++ b/FindGFlags.cmake
@@ -1,4 +1,5 @@
 include("GenericFindDependency")
+option(GFLAGS_STRIP_INTERNAL_FLAG_HELP "Hide help from GFLAGS modules" true)
 GenericFindDependency(
   TARGET gflags
   SOURCE_DIR "googleflags"


### PR DESCRIPTION
We have a forked version of gflags - https://github.com/swift-nav/gflags which recently Dennis Zollo added some commits that would remove a number of private details (see [SV4-145](https://swift-nav.atlassian.net/browse/SV4-145)).

With these changes, any googleflag repository that uses our forked version won't have the following entrys in the help message:

```
Flags from ../../../third_party/googleflags/src/gflags.cc:
    --flagfile (load flags from file) type: string default: ""
    --fromenv (set flags from the environment [use 'export FLAGS_flag1=value'])
      type: string default: ""
    --tryfromenv (set flags from the environment if present) type: string
      default: ""
    --undefok (comma-separated list of flag names that it is okay to specify on
      the command line even if the program does not define a flag with that
      name.  IMPORTANT: flags in this list that have arguments MUST use the
      flag=value format) type: string default: ""

  Flags from ../../../third_party/googleflags/src/gflags_completions.cc:
    --tab_completion_columns (Number of columns to use in output for tab
      completion) type: int32 default: 80
    --tab_completion_word (If non-empty, HandleCommandLineCompletions() will
      hijack the process and attempt to do bash-style command line flag
      completion on this value.) type: string default: ""

  Flags from ../../../third_party/googleflags/src/gflags_reporting.cc:
    --help (show help on all flags [tip: all flags can have two dashes])
      type: bool default: false currently: true
    --helpfull (show help on all flags -- same as -help) type: bool
      default: false
    --helpmatch (show help on modules whose name contains the specified substr)
      type: string default: ""
    --helpon (show help on the modules named by this flag value) type: string
      default: ""
    --helppackage (show help on all modules in the main package) type: bool
      default: false
    --helpshort (show help on only the main module for this program) type: bool
      default: false
    --helpxml (produce an xml version of help) type: bool default: false
    --version (show version and build info and exit) type: bool default: false
```

It also removed `Flags from *` which in `starling` currently shows our source file paths.