### PR TITLE
Enable C extensions in tests

### DIFF
--- a/LanguageStandards.cmake
+++ b/LanguageStandards.cmake
@@ -3,6 +3,8 @@
 # wide C/C++ standard version. One can bypass some of these standards through
 # the following options:
 #
+#   C_EXTENSIONS_ON: Turns on C_EXTENSIONS in the target properties if specified (see: https://cmake.org/cmake/help/latest/prop_tgt/C_EXTENSIONS.html)
+#
 # Single Value Options:
 #
 #  C: C language standard to follow, current support values are 90, 99, and 11 (see: https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html)
@@ -26,7 +28,7 @@
 #
 
 function(swift_set_language_standards)
-    set(argOption "")
+    set(argOption C_EXTENSIONS_ON)
     set(argSingle "C" "CXX")
     set(argMulti "")
 
@@ -40,11 +42,17 @@ function(swift_set_language_standards)
         set(x_CXX 14)
     endif()
 
+    set(C_EXTENSIONS ON)
+
+    if(NOT x_C_EXTENSIONS_ON)
+        set(C_EXTENSIONS OFF)
+    endif()
+
     set_target_properties(${x_UNPARSED_ARGUMENTS}
         PROPERTIES
             C_STANDARD ${x_C}
             C_STANDARD_REQUIRED ON
-            C_EXTENSIONS OFF
+            C_EXTENSIONS ${C_EXTENSIONS}
             CXX_STANDARD ${x_CXX}
             CXX_STANDARD_REQUIRED ON
             CXX_EXTENSIONS OFF

--- a/TestTargets.cmake
+++ b/TestTargets.cmake
@@ -256,7 +256,7 @@ function(swift_add_test target)
   endif()
 
   add_executable(${target} EXCLUDE_FROM_ALL ${x_SRCS})
-  swift_set_language_standards(${target})
+  swift_set_language_standards(${target} C_EXTENSIONS_ON)
   if(x_INCLUDE)
     target_include_directories(${target} PRIVATE ${x_INCLUDE})
   endif()


### PR DESCRIPTION
Some tests rely on GNU compiler extensions, so it's useful to enable compiler extensions for all tests.