### PR TITLE
[ESD-2038] Script to check for misused of __attribute__

### DIFF
--- a/CheckAttributes.cmake
+++ b/CheckAttributes.cmake
@@ -1,0 +1,8 @@
+if(TARGET check-attributes)
+  return()
+endif()
+
+add_custom_target(check-attributes ALL
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/scripts/check_attributes.sh
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )

--- a/CheckAttributes.cmake
+++ b/CheckAttributes.cmake
@@ -22,7 +22,7 @@ function(create_check_attributes_target)
 
   cmake_parse_arguments(x "${argOption}" "${argSingle}" "${argMulti}" ${ARGN})
 
-  set(arguments "'*.[ch]'" "'*.[ch]pp'" "'*.cc'")
+  set(arguments "'*.[ch]'" "'*.[ch]pp'" "'*.cc'" "'*.[ch]xx'")
   foreach(excl ${x_EXCLUDE})
     list(APPEND arguments ":!:${excl}")
   endforeach()

--- a/CheckAttributes.cmake
+++ b/CheckAttributes.cmake
@@ -1,3 +1,15 @@
+#
+# Copyright (C) 2021 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+
 function(create_check_attributes_target)
   if(NOT ${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
     # Only create for top level projects

--- a/CheckAttributes.cmake
+++ b/CheckAttributes.cmake
@@ -1,8 +1,23 @@
-if(TARGET check-attributes)
-  return()
-endif()
+function(create_check_attributes_target)
+  if(NOT ${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
+    # Only create for top level projects
+    return()
+  endif()
 
-add_custom_target(check-attributes ALL
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/scripts/check_attributes.sh
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  )
+  set(argOption "")
+  set(argSingle "")
+  set(argMulti "EXCLUDE")
+
+  cmake_parse_arguments(x "${argOption}" "${argSingle}" "${argMulti}" ${ARGN})
+
+  set(arguments "'*.[ch]'" "'*.[ch]pp'" "'*.cc'")
+  foreach(excl ${x_EXCLUDE})
+    list(APPEND arguments ":!:${excl}")
+  endforeach()
+
+  add_custom_target(check-attributes ALL
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/common/scripts/check_attributes.sh ${arguments}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    )
+
+endfunction()

--- a/scripts/check_attributes.sh
+++ b/scripts/check_attributes.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
 failed=0
-files=$(grep -l __attribute__ $(git ls-files '*.[ch]') $(git ls-files '*.[ch]pp') $(git ls-files '*.cc'))
+files=$(grep -l __attribute__ $(git ls-files $@))
 
 if [[ -n "$files" ]];
 then
-  grep -n __attribute__ $files |
+  grep -Hn __attribute__ $files |
     while read line;
     do
-      echo $(pwd)/$line
+      # Output a message similar to a compiler error so that editors/IDEs can parse it
+      location=$(echo "$line" | cut -d: -f-2)
+      code=$(echo "$line" | cut -d: -f3-)
+      echo $(pwd)/$location: error: Do not use __attribute__, prefer one of the macros from swiftnav/macros.h
+      echo "          $code"
     done
   failed=1
 fi

--- a/scripts/check_attributes.sh
+++ b/scripts/check_attributes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (C) 2021 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -14,7 +14,7 @@
 failed=0
 files=$(grep -l __attribute__ $(git ls-files $@))
 
-if [[ -n "$files" ]];
+if [ -n "$files" ];
 then
   grep -Hn __attribute__ $files |
     while read line;

--- a/scripts/check_attributes.sh
+++ b/scripts/check_attributes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+failed=0
+files=$(grep -l __attribute__ $(git ls-files '*.[ch]') $(git ls-files '*.[ch]pp') $(git ls-files '*.cc'))
+
+if [[ -n "$files" ]];
+then
+  grep -n __attribute__ $files |
+    while read line;
+    do
+      echo $(pwd)/$line
+    done
+  failed=1
+fi
+
+exit $failed

--- a/scripts/check_attributes.sh
+++ b/scripts/check_attributes.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Copyright (C) 2021 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+
 failed=0
 files=$(grep -l __attribute__ $(git ls-files $@))
 


### PR DESCRIPTION
The use of plain `__attribute__` is causing some portability issues. https://github.com/swift-nav/libswiftnav-private/pull/274 introduces a header to abstract away attributes behind some preprocessor macros which are protected and redefined by compiler detecting `#if` blocks

This script is a parallel effort to help prevent future erroneous usage of `__attribute__`. This module and script can be used by any project and adds a new target which looks through all source and header files in a repository and flags an IDE parsable error should `__attribute__` be used anywhere. The script is fairly dumb and just greps through all files tracked by git. It's not a perfect solution but will definitely fail CI in the event of a misuse.

This has been demonstrated in other Swift repositories in a series of other PRs