### PR TITLE
ESD-2197: Enable tracking origins in memcheck

### DIFF
--- a/Valgrind.cmake
+++ b/Valgrind.cmake
@@ -302,6 +302,7 @@ function(swift_add_valgrind_memcheck target)
   _valgrind_arguments_setup(${target} ${valgrind_tool} "${argOption}" "${argSingle}" "${argMulti}" "${ARGN}")
 
   list(APPEND valgrind_tool_options --tool=${valgrind_tool})
+  list(APPEND valgrind_tool_options --track-origins=yes)
 
   if (x_TRACE_CHILDREN)
     list(APPEND valgrind_tool_options --xml=yes --xml-file=${output_file}.xml.%p)
@@ -311,10 +312,6 @@ function(swift_add_valgrind_memcheck target)
 
   if (x_SHOW_REACHABLE)
     list(APPEND valgrind_tool_options --show-reachable=yes)
-  endif()
-
-  if (x_TRACK_ORIGINS)
-    list(APPEND valgrind_tool_options --track-origins=yes)
   endif()
 
   if (x_UNDEF_VALUE_ERRORS)


### PR DESCRIPTION
# [ESD-2197](https://swift-nav.atlassian.net/browse/ESD-2197): Enable tracking origins in memcheck

## Design

We always want to enable tracking origins by default to make tracking down failures from the Jenkins output easier. This shouldn't add much to the build.

[Slack](https://snav.slack.com/archives/C02USAD03/p1629170011072400?thread_ts=1629134037.064500&cid=C02USAD03)

## Testing

https://github.com/swift-nav/starling/pull/5657