### PR TITLE
fix: use correct target types for compilable targets

### DIFF
--- a/ListTargets.cmake
+++ b/ListTargets.cmake
@@ -107,7 +107,8 @@ function(swift_list_compilable_targets out_var)
     ${out_var}
     TYPES
     "EXECUTABLE"
-    "DYNAMIC_LIBRARY"
+    "MODULE_LIBRARY"
+    "SHARED_LIBRARY"
     "STATIC_LIBRARY"
     "OBJECT_LIBRARY"
     ${ARGN})


### PR DESCRIPTION
Function ``swift_list_compilable_targets`` in `ListTargets,cmake` filters targets using target types that are not the ones returned by cmake ``get_target_property(TYPE)``.

The correct list should be:
```
    "EXECUTABLE"
    "MODULE_LIBRARY"
    "SHARED_LIBRARY"
    "STATIC_LIBRARY"
    "OBJECT_LIBRARY"
```