### PR TITLE
Update Optional Target

### DIFF
--- a/FindOptional.cmake
+++ b/FindOptional.cmake
@@ -13,6 +13,6 @@
 include("GenericFindDependency")
 option(optional_ENABLE_TESTS "" OFF)
 GenericFindDependency(
-  TARGET optional
+  TARGET akrzemi1::optional
   SYSTEM_INCLUDES
 )

--- a/FindOptional.cmake
+++ b/FindOptional.cmake
@@ -13,6 +13,6 @@
 include("GenericFindDependency")
 option(optional_ENABLE_TESTS "" OFF)
 GenericFindDependency(
-  TARGET akrzemi1_optional
+  TARGET akrzemi1::optional
   SYSTEM_INCLUDES
 )

--- a/FindOptional.cmake
+++ b/FindOptional.cmake
@@ -13,6 +13,6 @@
 include("GenericFindDependency")
 option(optional_ENABLE_TESTS "" OFF)
 GenericFindDependency(
-  TARGET akrzemi1::optional
+  TARGET akrzemi1_optional
   SYSTEM_INCLUDES
 )


### PR DESCRIPTION
Updates the target that gets used in `FindOptional.cmake`. This does not affect clients that still link `optional` as the build still exports that name as an alias target.

see: https://github.com/swift-nav/Optional/pull/4