### PR TITLE
Integrity unit tests framework

### DIFF
--- a/FindAlbatross.cmake
+++ b/FindAlbatross.cmake
@@ -12,12 +12,12 @@
 
 include("GenericFindDependency")
 
-option(orion_proto_ENABLE_DOCS "" false)
-option(orion_proto_ENABLE_EXAMPLES "" false)
-option(orion_proto_ENABLE_TESTS "" false)
-option(orion_proto_ENABLE_TEST_LIBS "" false)
+option(albatross_ENABLE_DOCS "" false)
+option(albatross_ENABLE_EXAMPLES "" false)
+option(albatross_ENABLE_TESTS "" false)
+option(albatross_ENABLE_TEST_LIBS "" false)
 
 GenericFindDependency(
-  TARGET orion-proto
-  SOURCE_DIR orion_proto
+  TARGET albatross
+  SYSTEM_INCLUDES
 )

--- a/FindOrion-Engine.cmake
+++ b/FindOrion-Engine.cmake
@@ -12,12 +12,13 @@
 
 include("GenericFindDependency")
 
-option(orion_proto_ENABLE_DOCS "" false)
-option(orion_proto_ENABLE_EXAMPLES "" false)
-option(orion_proto_ENABLE_TESTS "" false)
-option(orion_proto_ENABLE_TEST_LIBS "" false)
+option(orion-engine_ENABLE_DOCS "" false)
+option(orion-engine_ENABLE_EXAMPLES "" false)
+option(orion-engine_ENABLE_TESTS "" false)
+option(orion-engine_ENABLE_TEST_LIBS "" false)
 
 GenericFindDependency(
-  TARGET orion-proto
-  SOURCE_DIR orion_proto
+  TARGET orion_engine
+  SOURCE_DIR orion-engine
+  SYSTEM_INCLUDES
 )

--- a/FindSip.cmake
+++ b/FindSip.cmake
@@ -12,12 +12,13 @@
 
 include("GenericFindDependency")
 
-option(orion_proto_ENABLE_DOCS "" false)
-option(orion_proto_ENABLE_EXAMPLES "" false)
-option(orion_proto_ENABLE_TESTS "" false)
-option(orion_proto_ENABLE_TEST_LIBS "" false)
+option(sip_ENABLE_DOCS "" false)
+option(sip_ENABLE_EXAMPLES "" false)
+option(sip_ENABLE_TESTS "" false)
+option(sip_ENABLE_TEST_LIBS "" false)
 
 GenericFindDependency(
-  TARGET orion-proto
-  SOURCE_DIR orion_proto
+  TARGET sip
+  SOURCE_DIR sip
+  SYSTEM_INCLUDES
 )

--- a/TestTargets.cmake
+++ b/TestTargets.cmake
@@ -197,8 +197,6 @@ function(swift_add_test_runner target)
     message(FATAL_ERROR "swift_add_test_runner unparsed arguments - ${x_UNPARSED_ARGUMENTS}")
   endif()
 
-  swift_create_test_targets()
-
   if(NOT x_COMMENT)
     set(x_COMMENT "test ${target}")
   endif()
@@ -212,6 +210,12 @@ function(swift_add_test_runner target)
   elseif(x_INTEGRATION_TEST AND x_UNIT_TEST)
     message(FATAL_ERROR "Both INTEGRATION_TEST and UNIT_TEST option were specified, you can only specify one")
   endif()
+
+  if (NOT ${PROJECT_NAME}_BUILD_TESTS)
+    return()
+  endif()
+
+  swift_create_test_targets()
 
   add_custom_target(
     do-${target}
@@ -266,8 +270,6 @@ function(swift_add_test target)
     message(FATAL_ERROR "swift_add_test unparsed arguments - ${x_UNPARSED_ARGUMENTS}")
   endif()
 
-  swift_create_test_targets()
-
   if(NOT x_SRCS)
     message(FATAL_ERROR "swift_add_test must be passed at least one source file")
   endif()
@@ -291,12 +293,19 @@ function(swift_add_test target)
   add_executable(${target} EXCLUDE_FROM_ALL ${x_SRCS})
   set_target_properties(${target} PROPERTIES SWIFT_TYPE "test")
   swift_set_language_standards(${target} C_EXTENSIONS_ON)
+  target_code_coverage(${target} AUTO ALL)
   if(x_INCLUDE)
     target_include_directories(${target} PRIVATE ${x_INCLUDE})
   endif()
   if(x_LINK)
     target_link_libraries(${target} PRIVATE ${x_LINK})
   endif()
+
+  if (NOT ${PROJECT_NAME}_BUILD_TESTS)
+    return()
+  endif()
+
+  swift_create_test_targets()
 
   add_custom_target(
     do-${target}
@@ -305,7 +314,6 @@ function(swift_add_test target)
     COMMENT "Running ${x_COMMENT}"
   )
   add_dependencies(do-${target} ${target})
-  target_code_coverage(${target} AUTO ALL)
 
   if(x_PARALLEL)
     add_custom_target(parallel-${target}


### PR DESCRIPTION
# Background

In looking to introduce unit/integration unit testing into Orion Engine for the Bosch integrity work, I've stumbled up on a few issues in Orion and friends. Firstly there aren't any `find_packge` scripts for `orion-engine`, `orion_proto`, `sip`, and `albatros` in this cmake repository, that isn't a problem since each repository has a custom script to include them in the `cmake/` directory rather than the `cmake/common`. The problem is that each of these scripts have not included the necessary `option(${PROJECT_NAME}_ENABLE_${FEATURE} "" false)` statements which is needed to control the inclusion of submodule test executable. 

This causes issues when running `do-all-tests` in `orion-engine` as unit tests from both `sip` (uses [swift_add_tests](https://github.com/swift-nav/sip/blob/0bed20094eda02a2b14aebbfbf9150144fd415e0/CMakeLists.txt#L256)) and `starling` (ex: the inclusion of [test-starling-output-analyzer](https://github.com/swift-nav/starling/blob/8bc2ba6309ce5eee08ed55cdf5d00d2d18b6e8a9/tools/starling-output-analyzer/test/unit/CMakeLists.txt#L13) isn't controlled by `starling_BUILD_TESTS` [here](https://github.com/swift-nav/starling/blob/8bc2ba6309ce5eee08ed55cdf5d00d2d18b6e8a9/tools/starling-output-analyzer/CMakeLists.txt#L49)) are executed. So to fix this, this PR does two things:

1. introduce the find_package scripts for the missing Swift repositories and marks all doc/tests/example as false
2. fixes up the `swift_add_test` and `swift_add_test_runner` functions so that even if the targets aren't protected by a `${PROJECT}_BUILD_TESTS` variable (and variants), it won't be included into the `do-all-tests` target.

# Testing

Ran the following script in Orion and than tried to compile the submodules (orion-engine, sip, orion_proto) after I removed the local find_package scripts.  

```shell
#!/usr/bin/bash

REPOSITORIES=(
    cmake/common/
    third_party/orion_proto/cmake/common/
    third_party/orion_proto/third_party/gnss-converters/c/cmake/common/
    third_party/orion_proto/third_party/gnss-converters/c/third_party/libsbp/c/cmake/common/
    third_party/orion_proto/third_party/gnss-converters/c/third_party/libswiftnav/cmake/common/
    third_party/orion_proto/third_party/sip/cmake/common/
    third_party/orion_proto/third_party/sip/third_party/libsbp/c/cmake/common/
    third_party/orion_proto/third_party/sip/third_party/libswiftnav/cmake/common/
    third_party/orion-engine/cmake/common/
    third_party/orion-engine/third_party/orion_proto/cmake/common
    third_party/orion-engine/third_party/orion_proto/third_party/gnss-converters/c/cmake/common/
    third_party/orion-engine/third_party/orion_proto/third_party/gnss-converters/c/third_party/libsbp/c/cmake/common/
    third_party/orion-engine/third_party/orion_proto/third_party/gnss-converters/c/third_party/libswiftnav/cmake/common/
    third_party/orion-engine/third_party/orion_proto/third_party/sip/cmake/common/
    third_party/orion-engine/third_party/orion_proto/third_party/sip/third_party/libsbp/c/cmake/common/
    third_party/orion-engine/third_party/orion_proto/third_party/sip/third_party/libswiftnav/cmake/common/
    third_party/orion-engine/third_party/starling/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/libpal/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/libsbp/c/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/libswiftnav/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/swiftlets/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/swiftlets/third_party/gnss-converters/c/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/swiftlets/third_party/gnss-converters/c/third_party/libsbp/c/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/swiftlets/third_party/gnss-converters/c/third_party/libswiftnav/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/swiftlets/third_party/libpal/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/swiftlets/third_party/libsbp/c/cmake/common/
    third_party/orion-engine/third_party/starling/third_party/swiftlets/third_party/libswiftnav/cmake/common/
)

for repository in ${REPOSITORIES[@]}
do
  git -C ${repository} fetch
done


for repository in ${REPOSITORIES[@]}
do
  git -C ${repository} checkout origin/rodrigor/integrity-unit-tests-framework
done
```

Also to verify that this won't have any impact on Starling, I created [this PR](https://github.com/swift-nav/starling/pull/6545).