### PR TITLE
Removed warning messages (Option #1)

### DIFF
--- a/SwiftCmakeOptions.cmake
+++ b/SwiftCmakeOptions.cmake
@@ -281,10 +281,4 @@ function(swift_create_project_options)
     endif()
   endif()
 
-  foreach(feat "TESTS" "TEST_LIBS" "DOCS" "EXAMPLES")
-    if(DEFINED ${x_PROJECT}_ENABLE_${feat} AND NOT x_HAS_${feat})
-      message(WARNING "${x_PROJECT}_ENABLE_${feat} is set but the package does not support it")
-    endif()
-  endforeach()
-
 endfunction()


### PR DESCRIPTION
# Background

This PR is one of two options (see other option https://github.com/swift-nav/cmake/pull/113)

This is a follow on PR after https://github.com/swift-nav/cmake/pull/111 was merged in. In the specified PR I added the following lines to the `find_package` scripts (this example is for albatross but the same can be said for a number of other orion repositories):

```CmakeLists.txt
option(albatross_ENABLE_DOCS "" false)
option(albatross_ENABLE_EXAMPLES "" false)
option(albatross_ENABLE_TESTS "" false)
option(albatross_ENABLE_TEST_LIBS "" false)
```

This caused a lot of warning messages to be triggered (which I've missed my testing). Personally I prefer to have all the features disabled by default when including them as submodules, to avoid having them enabled accidentally when one of them becomes available in a submodule project. Say that a new project gets added with HAS_TESTS as a project feature, that will be by default enabled when the auto submodule updates roll up through the other repositories.

**NOTE**: if this isn't a good viable solution, the alternative to dealing with these warnings is to properly disable only features that are available in the submodule which I'm happy to do.