### PR TITLE
Add clang format 11

### DIFF
--- a/ClangFormat.cmake
+++ b/ClangFormat.cmake
@@ -212,6 +212,7 @@ function(swift_setup_clang_format)
   # First try to find clang-format
   if(NOT x_CLANG_FORMAT_NAMES)
     set(x_CLANG_FORMAT_NAMES
+        clang-format11 clang-format-11
         clang-format60 clang-format-6.0
         clang-format40 clang-format-4.0
         clang-format39 clang-format-3.9


### PR DESCRIPTION
I'm running ubuntu and recently upgraded my clang version to match jenkins and in the process realized that cmake was still picking an older version of clang (clang-format-6.0). In this change I've added `clang-format-11` as the highest priority option which (I think) aligns with the clang-format used in things like orion engine's jenkins builds.

Note: I suspect we can do away with all the old versions listed in `ClangFormat.cmake`, but not sure if all projects are on 11 now?