### PR TITLE
Fix Generated sonar-project.properties Configuration

### DIFF
--- a/Sonarcloud.cmake
+++ b/Sonarcloud.cmake
@@ -194,13 +194,12 @@ function(generate_sonarcloud_project_properties sonarcloud_project_properties_pa
       test_library
   )
 
-  list(APPEND source_targets ${test_targets})
-
   _extract_sonarcloud_project_files(source_source_files source_include_directories ${source_targets})
+  _extract_sonarcloud_project_files(test_source_files test_include_directories ${test_targets})
 
   set(sonarcloud_project_properties_content "sonar.sourceEncoding=UTF-8\n")
 
-  set(source_files ${source_source_files} ${source_include_directories})
+  set(source_files ${source_source_files} ${source_include_directories} ${test_source_files})
   list(JOIN source_files ",${_sonarcloud_newline}" sonar_sources)
   string(APPEND sonarcloud_project_properties_content "sonar.sources=${_sonarcloud_newline}${sonar_sources}\n")
 

--- a/Sonarcloud.cmake
+++ b/Sonarcloud.cmake
@@ -202,7 +202,7 @@ function(generate_sonarcloud_project_properties sonarcloud_project_properties_pa
 
   set(source_files ${source_source_files} ${source_include_directories})
   list(JOIN source_files ",${_sonarcloud_newline}" sonar_sources)
-  string(APPEND sonarcloud_project_properties_content "sonar.inclusions=${_sonarcloud_newline}${sonar_sources}\n")
+  string(APPEND sonarcloud_project_properties_content "sonar.sources=${_sonarcloud_newline}${sonar_sources}\n")
 
   file(GENERATE
     OUTPUT "${sonarcloud_project_properties_path}"

--- a/Sonarcloud.cmake
+++ b/Sonarcloud.cmake
@@ -194,18 +194,15 @@ function(generate_sonarcloud_project_properties sonarcloud_project_properties_pa
       test_library
   )
 
+  list(APPEND source_targets ${test_targets})
+
   _extract_sonarcloud_project_files(source_source_files source_include_directories ${source_targets})
-  _extract_sonarcloud_project_files(test_source_files test_include_directories ${test_targets})
 
   set(sonarcloud_project_properties_content "sonar.sourceEncoding=UTF-8\n")
 
   set(source_files ${source_source_files} ${source_include_directories})
   list(JOIN source_files ",${_sonarcloud_newline}" sonar_sources)
   string(APPEND sonarcloud_project_properties_content "sonar.inclusions=${_sonarcloud_newline}${sonar_sources}\n")
-
-  set(test_files ${test_source_files})
-  list(JOIN test_files ",${_sonarcloud_newline}" sonar_tests)
-  string(APPEND sonarcloud_project_properties_content "sonar.tests.inclusions=${_sonarcloud_newline}${sonar_tests}\n")
 
   file(GENERATE
     OUTPUT "${sonarcloud_project_properties_path}"


### PR DESCRIPTION
Fixes test and header files not being analyzed by sonarcloud.

From the sonarcloud documentation:

>The sonar.tests property is used to identify the directories containing test source files. Identifying test files helps the analyzers to tune their rules. For example, the analyzers can enable test-specific rules and disable rules that don't make sense in the context of testing.

>The C/C++/Objective-C analyzer currently analyzes main and test source files in the same way. Consequently, sonar.tests is not yet supported; the analyzer ignores it.

>If you wish to analyze test source files, you should include them in the sonar.sources property.

Since we were putting all of our test files under `sonar.test.inclusions`, they were being ignored by the scanner.

This changes the `sonar.inclusions` property to `sonar.sources`, and appends the test paths to it instead of `sonar.tests`. With these changes, header and test files are properly analyzed by the sonar-scanner.