### PR TITLE
sonarcloud: Use Inclusions Property

### DIFF
--- a/Sonarcloud.cmake
+++ b/Sonarcloud.cmake
@@ -200,8 +200,11 @@ function(generate_sonarcloud_project_properties sonarcloud_project_properties_pa
   set(sonarcloud_project_properties_content "sonar.sourceEncoding=UTF-8\n")
 
   set(source_files ${source_source_files} ${source_include_directories} ${test_source_files})
+  foreach (dir ${source_include_directories})
+    set(source_files ${source_files} ${dir}/*.h ${dir}/**/*.h)
+  endforeach()
   list(JOIN source_files ",${_sonarcloud_newline}" sonar_sources)
-  string(APPEND sonarcloud_project_properties_content "sonar.sources=${_sonarcloud_newline}${sonar_sources}\n")
+  string(APPEND sonarcloud_project_properties_content "sonar.inclusions=${_sonarcloud_newline}${sonar_sources}\n")
 
   file(GENERATE
     OUTPUT "${sonarcloud_project_properties_path}"


### PR DESCRIPTION
Fixes Code Coverage builds by switching to using the `sonar.inclusions` property.

Some of our build targets set their source directories in the include paths. Those paths are then emitted in the `sonar-project.properties` file here. The issue is that this can lead to files being indexed twice which the sonar-scanner treats as an error.

For example the generated file can look something like:
```properties
sonar.sources=
  foo/src/foo.cpp, \ # Absolute path to cpp file
  foo/src/ # Picked up from include paths. Causes scanner to scan foo.cpp twice
```

The inclusions property requires that we use a pattern string instead of paths, so include paths are modified with the appropriate pattern to ensure header files are included in the analysis.

See related PR for testing details:
- https://github.com/swift-nav/starling/pull/6837
- https://github.com/swift-nav/starling-core/pull/16