### PR TITLE
Module to automatically fix include guards [ESD-2468]

### DIFF
--- a/IncludeGuards.cmake
+++ b/IncludeGuards.cmake
@@ -1,3 +1,33 @@
+#
+# Copyright (C) 2021 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+
+#
+# A module to check header files for:
+# - Include guards
+# - Copyright notice
+#
+# When included will create 2 new targets:
+# - fix-include-guards - Check all header files in the repository for the
+#   above conditions
+# - fix-include-guards-check - Depends on fix-include-guards then exits with
+#   an error code if any changes were applied. Useful for enforcing checks
+#   during CI runs
+#
+# Include guards are formatted according to the header file's location in the
+# source tree. Copyright notices are boiler plate block comments
+#
+# Changes are applied in place
+#
+
 add_custom_target(fix-include-guards-${PROJECT_NAME}
   COMMAND
     ${CMAKE_CURRENT_LIST_DIR}/scripts/fix_include_guards.py `git ls-files '*.h'`

--- a/IncludeGuards.cmake
+++ b/IncludeGuards.cmake
@@ -1,0 +1,14 @@
+add_custom_target(fix-include-guards-${PROJECT_NAME}
+  COMMAND ${CMAKE_CURRENT_LIST_DIR}/scripts/fix_include_guards.py `git ls-files '*.h'`
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )
+add_custom_target(fix-include-guards-check-${PROJECT_NAME}
+  COMMAND git diff --exit-code
+  DEPENDS fix-include-guards-${PROJECT_NAME}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )
+
+if(${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
+  add_custom_target(fix-include-guards DEPENDS fix-include-guards-${PROJECT_NAME})
+  add_custom_target(fix-include-guards-check DEPENDS fix-include-guards-check-${PROJECT_NAME})
+endif()

--- a/IncludeGuards.cmake
+++ b/IncludeGuards.cmake
@@ -1,14 +1,21 @@
 add_custom_target(fix-include-guards-${PROJECT_NAME}
-  COMMAND ${CMAKE_CURRENT_LIST_DIR}/scripts/fix_include_guards.py `git ls-files '*.h'`
+  COMMAND
+    ${CMAKE_CURRENT_LIST_DIR}/scripts/fix_include_guards.py `git ls-files '*.h'`
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  )
+)
 add_custom_target(fix-include-guards-check-${PROJECT_NAME}
   COMMAND git diff --exit-code
   DEPENDS fix-include-guards-${PROJECT_NAME}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  )
+)
 
 if(${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
-  add_custom_target(fix-include-guards DEPENDS fix-include-guards-${PROJECT_NAME})
-  add_custom_target(fix-include-guards-check DEPENDS fix-include-guards-check-${PROJECT_NAME})
+  add_custom_target(
+    fix-include-guards
+    DEPENDS fix-include-guards-${PROJECT_NAME}
+  )
+  add_custom_target(
+    fix-include-guards-check
+    DEPENDS fix-include-guards-check-${PROJECT_NAME}
+  )
 endif()

--- a/scripts/fix_include_guards.py
+++ b/scripts/fix_include_guards.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+import codecs
+import sys
+import re
+
+def FixHeaderGuard(filename):
+  try:
+    with codecs.open(filename, 'r', 'utf8', 'replace') as target_file:
+      lines = target_file.read().split('\n')
+
+    # Remove trailing '\r'.
+    # The -1 accounts for the extra trailing blank line we get from split()
+    for linenum in range(len(lines) - 1):
+      if lines[linenum].endswith('\r'):
+        lines[linenum] = lines[linenum].rstrip('\r')
+
+  except IOError:
+    sys.stderr.write(
+        "Skipping input '%s': Can't open for reading\n" % filename)
+    return
+
+  # Don't check for header guards if there are error suppression
+  # comments somewhere in this file.
+  #
+  # Because this is silencing a warning for a nonexistent line, we
+  # only support the very specific NOLINT(build/header_guard) syntax,
+  # and not the general NOLINT or NOLINT(*) syntax.
+  raw_lines = lines
+  for i in raw_lines:
+    if re.match(r'//\s*NOLINT\(build/header_guard\)', i):
+      return
+
+  # Allow pragma once instead of header guards
+  for i in raw_lines:
+    if re.match(r'^\s*#pragma\s+once', i):
+      return
+
+  print("filename %s" % filename)
+  if re.match(r'.*/include/.*', filename):
+    expected_guard = re.sub(r'^.*/include/', '', filename)
+  elif re.match(r'^include/.*', filename):
+    expected_guard = re.sub(r'^include/', '', filename)
+  else:
+    # header is probably just loose in a source directory so we'll have to use
+    # something else
+
+    components = filename.split('/')
+    parent_dir = components[-2:][0]
+    print("parent_dir %s" % parent_dir)
+    print(components)
+    if parent_dir == "src":
+        # In the case where we're in a directory called 'src' start two levels up
+        expected_guard = '_'.join(components[-3:])
+    else:
+        # otherwise just use the parent directory name
+        expected_guard = '_'.join(components[-2:])
+
+  expected_guard = re.sub(r'\+\+', 'cpp', expected_guard)
+  expected_guard = re.sub(r'[/\.-]', '_', expected_guard).upper()
+
+  sys.stdout.write('Expected guard: %s\n' % expected_guard)
+
+  ifndef = ''
+  ifndef_linenum = -1
+  define = ''
+  define_linenum = -1
+  for linenum, line in enumerate(raw_lines):
+    linesplit = line.split()
+    if len(linesplit) >= 2:
+      # find the first occurrence of #ifndef and #define, save arg
+      if not ifndef and linesplit[0] == '#ifndef':
+        # set ifndef to the header guard presented on the #ifndef line.
+        ifndef = linesplit[1]
+        ifndef_linenum = linenum
+      if not define and linesplit[0] == '#define':
+        define = linesplit[1]
+        define_linenum = linenum
+
+  if ifndef_linenum == -1 or ifndef != expected_guard or define_linenum == -1 or define != expected_guard:
+    if ifndef_linenum == -1:
+      # file doesn't have an include guard so generate one
+      lines.insert(0, "#ifndef %s\n#define %s\n" % (expected_guard, expected_guard))
+      lines.append("\n#endif")
+    else: 
+      # need to fix
+      lines[ifndef_linenum] = "#ifndef " + expected_guard
+      lines[define_linenum] = "#define " + expected_guard
+
+  # Check for copyright notice
+  default_copyright = """/**
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */"""
+
+  # We'll say it should occur by line 10. Don't forget there's a
+  # placeholder line at the front.
+  for line in range(1, min(len(lines), 11)):
+    if re.search(r'Copyright', lines[line], re.I):
+        break
+  else:                       # means no copyright line was found
+    # Generate a default copyright notice
+    lines.insert(0, default_copyright)
+
+  with codecs.open(filename, 'w', 'utf8', 'replace') as output_file:
+    output_file.write('\n'.join(lines))
+
+def main():
+    for filename in sys.argv[1:]:
+        FixHeaderGuard(filename)
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/fix_include_guards.py
+++ b/scripts/fix_include_guards.py
@@ -1,89 +1,108 @@
 #!/usr/bin/env python3
 
+#
+# Copyright (C) 2021 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+
 import codecs
 import sys
 import re
 
+
 def FixHeaderGuard(filename):
-  try:
-    with codecs.open(filename, 'r', 'utf8', 'replace') as target_file:
-      lines = target_file.read().split('\n')
+    try:
+        with codecs.open(filename, "r", "utf8", "replace") as target_file:
+            lines = target_file.read().split("\n")
 
-    # Remove trailing '\r'.
-    # The -1 accounts for the extra trailing blank line we get from split()
-    for linenum in range(len(lines) - 1):
-      if lines[linenum].endswith('\r'):
-        lines[linenum] = lines[linenum].rstrip('\r')
+        # Remove trailing '\r'.
+        # The -1 accounts for the extra trailing blank line we get from split()
+        for linenum in range(len(lines) - 1):
+            if lines[linenum].endswith("\r"):
+                lines[linenum] = lines[linenum].rstrip("\r")
 
-  except IOError:
-    sys.stderr.write(
-        "Skipping input '%s': Can't open for reading\n" % filename)
-    return
+    except IOError:
+        sys.stderr.write("Skipping input '%s': Can't open for reading\n" % filename)
+        return
 
-  # Don't check for header guards if there are error suppression
-  # comments somewhere in this file.
-  #
-  # Because this is silencing a warning for a nonexistent line, we
-  # only support the very specific NOLINT(build/header_guard) syntax,
-  # and not the general NOLINT or NOLINT(*) syntax.
-  raw_lines = lines
-  for i in raw_lines:
-    if re.match(r'//\s*NOLINT\(build/header_guard\)', i):
-      return
+    # Don't check for header guards if there are error suppression
+    # comments somewhere in this file.
+    #
+    # Because this is silencing a warning for a nonexistent line, we
+    # only support the very specific NOLINT(build/header_guard) syntax,
+    # and not the general NOLINT or NOLINT(*) syntax.
+    raw_lines = lines
+    for i in raw_lines:
+        if re.match(r"//\s*NOLINT\(build/header_guard\)", i):
+            return
 
-  # Allow pragma once instead of header guards
-  for i in raw_lines:
-    if re.match(r'^\s*#pragma\s+once', i):
-      return
+    # Allow pragma once instead of header guards
+    for i in raw_lines:
+        if re.match(r"^\s*#pragma\s+once", i):
+            return
 
-  if re.match(r'.*/include/.*', filename):
-    expected_guard = re.sub(r'^.*/include/', '', filename)
-  elif re.match(r'^include/.*', filename):
-    expected_guard = re.sub(r'^include/', '', filename)
-  else:
-    # header is probably just loose in a source directory so we'll have to use
-    # something else
-
-    components = filename.split('/')
-    parent_dir = components[-2:][0]
-    if parent_dir == "src":
-        # In the case where we're in a directory called 'src' start two levels up
-        expected_guard = '_'.join(components[-3:])
+    if re.match(r".*/include/.*", filename):
+        expected_guard = re.sub(r"^.*/include/", "", filename)
+    elif re.match(r"^include/.*", filename):
+        expected_guard = re.sub(r"^include/", "", filename)
     else:
-        # otherwise just use the parent directory name
-        expected_guard = '_'.join(components[-2:])
+        # header is probably just loose in a source directory so we'll have to use
+        # something else
 
-  expected_guard = re.sub(r'\+\+', 'cpp', expected_guard)
-  expected_guard = re.sub(r'[/\.-]', '_', expected_guard).upper()
+        components = filename.split("/")
+        parent_dir = components[-2:][0]
+        if parent_dir == "src":
+            # In the case where we're in a directory called 'src' start two levels up
+            expected_guard = "_".join(components[-3:])
+        else:
+            # otherwise just use the parent directory name
+            expected_guard = "_".join(components[-2:])
 
-  ifndef = ''
-  ifndef_linenum = -1
-  define = ''
-  define_linenum = -1
-  for linenum, line in enumerate(raw_lines):
-    linesplit = line.split()
-    if len(linesplit) >= 2:
-      # find the first occurrence of #ifndef and #define, save arg
-      if not ifndef and linesplit[0] == '#ifndef':
-        # set ifndef to the header guard presented on the #ifndef line.
-        ifndef = linesplit[1]
-        ifndef_linenum = linenum
-      if not define and linesplit[0] == '#define':
-        define = linesplit[1]
-        define_linenum = linenum
+    expected_guard = re.sub(r"\+\+", "cpp", expected_guard)
+    expected_guard = re.sub(r"[/\.-]", "_", expected_guard).upper()
 
-  if ifndef_linenum == -1 or ifndef != expected_guard or define_linenum == -1 or define != expected_guard:
-    if ifndef_linenum == -1:
-      # file doesn't have an include guard so generate one
-      lines.insert(0, "#ifndef %s\n#define %s\n" % (expected_guard, expected_guard))
-      lines.append("\n#endif")
-    else: 
-      # need to fix
-      lines[ifndef_linenum] = "#ifndef " + expected_guard
-      lines[define_linenum] = "#define " + expected_guard
+    ifndef = ""
+    ifndef_linenum = -1
+    define = ""
+    define_linenum = -1
+    for linenum, line in enumerate(raw_lines):
+        linesplit = line.split()
+        if len(linesplit) >= 2:
+            # find the first occurrence of #ifndef and #define, save arg
+            if not ifndef and linesplit[0] == "#ifndef":
+                # set ifndef to the header guard presented on the #ifndef line.
+                ifndef = linesplit[1]
+                ifndef_linenum = linenum
+            if not define and linesplit[0] == "#define":
+                define = linesplit[1]
+                define_linenum = linenum
 
-  # Check for copyright notice
-  default_copyright = """/**
+    if (
+        ifndef_linenum == -1
+        or ifndef != expected_guard
+        or define_linenum == -1
+        or define != expected_guard
+    ):
+        if ifndef_linenum == -1:
+            # file doesn't have an include guard so generate one
+            lines.insert(
+                0, "#ifndef %s\n#define %s\n" % (expected_guard, expected_guard)
+            )
+            lines.append("\n#endif")
+        else:
+            # need to fix
+            lines[ifndef_linenum] = "#ifndef " + expected_guard
+            lines[define_linenum] = "#define " + expected_guard
+
+    # Check for copyright notice
+    default_copyright = """/**
  * Copyright (C) 2022 Swift Navigation Inc.
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
@@ -95,22 +114,23 @@ def FixHeaderGuard(filename):
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */"""
 
-  # We'll say it should occur by line 10. Don't forget there's a
-  # placeholder line at the front.
-  for line in range(1, min(len(lines), 11)):
-    if re.search(r'Copyright', lines[line], re.I):
-        break
-  else:                       # means no copyright line was found
-    # Generate a default copyright notice
-    lines.insert(0, default_copyright)
+    # We'll say it should occur by line 10. Don't forget there's a
+    # placeholder line at the front.
+    for line in range(1, min(len(lines), 11)):
+        if re.search(r"Copyright", lines[line], re.I):
+            break
+    else:  # means no copyright line was found
+        # Generate a default copyright notice
+        lines.insert(0, default_copyright)
 
-  with codecs.open(filename, 'w', 'utf8', 'replace') as output_file:
-    output_file.write('\n'.join(lines))
+    with codecs.open(filename, "w", "utf8", "replace") as output_file:
+        output_file.write("\n".join(lines))
+
 
 def main():
     for filename in sys.argv[1:]:
         FixHeaderGuard(filename)
 
-if __name__ == '__main__':
-    main()
 
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_include_guards.py
+++ b/scripts/fix_include_guards.py
@@ -36,7 +36,6 @@ def FixHeaderGuard(filename):
     if re.match(r'^\s*#pragma\s+once', i):
       return
 
-  print("filename %s" % filename)
   if re.match(r'.*/include/.*', filename):
     expected_guard = re.sub(r'^.*/include/', '', filename)
   elif re.match(r'^include/.*', filename):
@@ -47,8 +46,6 @@ def FixHeaderGuard(filename):
 
     components = filename.split('/')
     parent_dir = components[-2:][0]
-    print("parent_dir %s" % parent_dir)
-    print(components)
     if parent_dir == "src":
         # In the case where we're in a directory called 'src' start two levels up
         expected_guard = '_'.join(components[-3:])
@@ -58,8 +55,6 @@ def FixHeaderGuard(filename):
 
   expected_guard = re.sub(r'\+\+', 'cpp', expected_guard)
   expected_guard = re.sub(r'[/\.-]', '_', expected_guard).upper()
-
-  sys.stdout.write('Expected guard: %s\n' % expected_guard)
 
   ifndef = ''
   ifndef_linenum = -1


### PR DESCRIPTION
A small script which can perform some linting on header files:
- Check that include guard matches the required pattern based on location in the source tree
- Add a copyright banner if missing

Changes are applied in place to any files

Added a cmake module which creates 2 new targets
- fix-include-guards - Run the python script to fix any errors
- fix-include-guards-check - Similar to clang-format-check, runs the script and then checks if any changes were applied returning an exit code if so. Can be used to fail a CI lint/format checking stage

python script is a cut down version of cpplint, removing all the stuff which isn't really relevant and adding the section for copyright notices