### PR TITLE
Fix empty test source files

### DIFF
--- a/Sonarcloud.cmake
+++ b/Sonarcloud.cmake
@@ -210,12 +210,14 @@ function(generate_sonarcloud_project_properties sonarcloud_project_properties_pa
   list(JOIN source_files ",${_sonarcloud_newline}" sonar_sources)
   string(APPEND sonarcloud_project_properties_content "sonar.inclusions=${_sonarcloud_newline}${sonar_sources}\n")
 
-  set(test_files ${test_source_files})
-  foreach(source_file ${source_source_files})
-    list(REMOVE_ITEM test_files ${source_file})
-  endforeach()
-  list(JOIN test_files ",${_sonarcloud_newline}" sonar_test_files)
-  string(APPEND sonarcloud_project_properties_content "sonar.coverage.exclusions=${_sonarcloud_newline}${sonar_test_files}\n")
+  if(test_source_files)
+    set(test_files ${test_source_files})
+    foreach(source_file ${source_source_files})
+      list(REMOVE_ITEM test_files ${source_file})
+    endforeach()
+    list(JOIN test_files ",${_sonarcloud_newline}" sonar_test_files)
+    string(APPEND sonarcloud_project_properties_content "sonar.coverage.exclusions=${_sonarcloud_newline}${sonar_test_files}\n")
+  endif()
 
   file(GENERATE
     OUTPUT "${sonarcloud_project_properties_path}"


### PR DESCRIPTION
After merging [Fix Sonarcloud sonar-project.properties](https://github.com/swift-nav/cmake/pull/127) PR some Starling toolchains complain about `test_files` list is empty.
https://github.com/swift-nav/starling/pull/6942

I tested this fix in the Starling repo:
https://github.com/swift-nav/starling/pull/6944