### PR TITLE
compile compile command cleanup

### DIFF
--- a/FindGrpc.cmake
+++ b/FindGrpc.cmake
@@ -1,0 +1,9 @@
+include("GenericFindDependency")
+
+option(ABSL_PROPAGATE_CXX_STD "Use CMake C++ standard meta features (e.g. cxx_std_11) that propagate to targets that link to Abseil" true)
+
+GenericFindDependency(
+  TARGET grpc++
+  SOURCE_DIR grpc
+  SYSTEM_INCLUDES
+)

--- a/FindOrion-Engine.cmake
+++ b/FindOrion-Engine.cmake
@@ -12,10 +12,7 @@
 
 include("GenericFindDependency")
 
-option(orion-engine_ENABLE_DOCS "" false)
-option(orion-engine_ENABLE_EXAMPLES "" false)
 option(orion-engine_ENABLE_TESTS "" false)
-option(orion-engine_ENABLE_TEST_LIBS "" false)
 
 GenericFindDependency(
   TARGET orion_engine

--- a/FindPrometheus-Cpp.cmake
+++ b/FindPrometheus-Cpp.cmake
@@ -3,9 +3,9 @@ option(ENABLE_TESTING "Build tests" OFF)
 option(ENABLE_PUSH "Build prometheus-cpp push library" OFF)
 option(ENABLE_COMPRESSION "Enable gzip compression" ON)
 GenericFindDependency(
-    TARGET prometheus-cpp::core
-    SOURCE_DIR "prometheus-cpp"
-    )
+  TARGET prometheus-cpp::core
+  SOURCE_DIR "prometheus-cpp"
+)
 
 # Change all of Prometheus's include directories to be system includes, to avoid
 # compiler errors. The generalised version of this in GenericFindDependency won't

--- a/FindPrometheus-Cpp.cmake
+++ b/FindPrometheus-Cpp.cmake
@@ -1,0 +1,32 @@
+include("GenericFindDependency")
+option(ENABLE_TESTING "Build tests" OFF)
+option(ENABLE_PUSH "Build prometheus-cpp push library" OFF)
+option(ENABLE_COMPRESSION "Enable gzip compression" ON)
+GenericFindDependency(
+    TARGET prometheus-cpp::core
+    SOURCE_DIR "prometheus-cpp"
+    )
+
+# Change all of Prometheus's include directories to be system includes, to avoid
+# compiler errors. The generalised version of this in GenericFindDependency won't
+# work here because we are dealing with an aliased target
+get_target_property(_aliased prometheus-cpp::core ALIASED_TARGET)
+if(_aliased)
+  get_target_property(prometheus_include_directories ${_aliased} INTERFACE_INCLUDE_DIRECTORIES)
+  if(prometheus_include_directories)
+    set_target_properties(${_aliased} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
+    target_include_directories(${_aliased} SYSTEM INTERFACE ${prometheus_include_directories})
+  endif()
+endif()
+
+# Change all of Prometheus's include directories to be system includes, to avoid
+# compiler errors. The generalised version of this in GenericFindDependency won't
+# work here because we are dealing with an aliased target
+get_target_property(_aliased prometheus-cpp::pull ALIASED_TARGET)
+if(_aliased)
+  get_target_property(prometheus_include_directories ${_aliased} INTERFACE_INCLUDE_DIRECTORIES)
+  if(prometheus_include_directories)
+    set_target_properties(${_aliased} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
+    target_include_directories(${_aliased} SYSTEM INTERFACE ${prometheus_include_directories})
+  endif()
+endif()

--- a/scripts/compile_commands_cleanup.py
+++ b/scripts/compile_commands_cleanup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#
+# Application will allow users to strip away source files from the compile_commands.json file.
+#
+
+import argparse
+import json
+import sys
+
+parser = argparse.ArgumentParser(description="Modifies a compile_commands.json file", allow_abbrev=False)
+parser.add_argument("file", type=str, help="path to the compile_commands.json file")
+parser.add_argument("--remove-third-party", action="store_true", help="removes all third party files")
+arguments = parser.parse_args()
+
+try:
+    with open(arguments.file, "r") as file:
+        data = json.load(file)
+
+    if arguments.remove_third_party:
+        data = [x for x in data if "third_party" not in x["file"]]
+
+    with open(arguments.file, "w") as file:
+        json.dump(data, file, indent=4)
+except BaseException as e:
+    print(e, file=sys.stderr)
+    exit(1)


### PR DESCRIPTION
## Changes

The main bit that I've change was introduce a new python script that can be used by Helix QAC to strip off any source file which it doesn't need to analyze. I've updated the script from where it was originally implemented [here](https://github.com/swift-nav/orion-engine/pull/4314#discussion_r957552705) so that its extensible for further develop (say something like white listing).

I've also done a few develop debt changes which have been on my plate since I'm already updating cmake:

1. I've moved a number of custom find package scripts from [here](https://github.com/swift-nav/orion/tree/master/cmake) to a common place
2. I've corrected an error I've made earlier where the find_package of orion-engine throw up warning messages about missing example/test libs/documentations.