### PR TITLE
Add ability to enable extra clang-tidy flags [BUILD-293]

### DIFF
--- a/ClangTidy.cmake
+++ b/ClangTidy.cmake
@@ -97,7 +97,7 @@ function(swift_create_clang_tidy_targets)
 
   set(argOption "DONT_GENERATE_CLANG_TIDY_CONFIG" "WITHOUT_SWIFT_TYPES")
   set(argSingle "")
-  set(argMulti "")
+  set(argMulti "FLAGS_TO_ENABLE")
 
   cmake_parse_arguments(x "${argOption}" "${argSingle}" "${argMulti}" ${ARGN})
   if(x_UNPARSED_ARGUMENTS)
@@ -244,6 +244,10 @@ function(swift_create_clang_tidy_targets)
         -readability-suspicious-call-argument
         -readability-uppercase-literal-suffix
         -readability-use-anyofallof)
+
+    foreach(flag IN LISTS x_FLAGS_TO_ENABLE)
+      list(FILTER disabled_checks EXCLUDE REGEX ${flag})
+    endforeach()
 
     # Final list of checks to enable/disable
     set(all_checks -* ${enabled_categories} ${disabled_checks})


### PR DESCRIPTION
This PR adds ability to enable extra clang-tidy flags. Flags can be passed as the argument to the `swift_create_clang_tidy_targets` function.
It has been tested in this PR:
https://github.com/swift-nav/orion/pull/4310