### PR TITLE
Disable starling core tests when used as a submodule

### DIFF
--- a/FindStarlingCore.cmake
+++ b/FindStarlingCore.cmake
@@ -12,9 +12,8 @@
 
 include("GenericFindDependency")
 
-option(starling_core_ENABLE_TESTS "" OFF)
-option(starling_core_ENABLE_TEST_LIBS "" OFF)
-option(starling_core_ENABLE_EXAMPLES "" OFF)
+option(starling-core_ENABLE_TESTS "" OFF)
+option(starling-core_ENABLE_TEST_LIBS "" OFF)
 
 GenericFindDependency(
   TARGET starling-core-utils


### PR DESCRIPTION
A typo in the options is preventing tests from being disabled when starling-core is used as a submodule. Also, the project doesn't (currently) have any examples