### PR TITLE
Fix nanopb version 0.4.6 [BUILD-380]

### DIFF
--- a/FindNanopb.cmake
+++ b/FindNanopb.cmake
@@ -12,6 +12,7 @@
 
 include("GenericFindDependency")
 option(nanopb_BUILD_GENERATOR "" OFF)
+option(NANOPB_PROTOC_OLDER_THAN_3_6_0 "" ON)
 GenericFindDependency(
   TARGET protobuf-nanopb
   SOURCE_DIR "nanopb"


### PR DESCRIPTION
This option is needed to use the newest nanopb with protoc older than 3.6.0.

Tested here: https://github.com/swift-nav/starling/pull/7239