### PR TITLE
Exclude unit test header files from coverage reporting

### DIFF
--- a/Sonarcloud.cmake
+++ b/Sonarcloud.cmake
@@ -216,6 +216,14 @@ function(generate_sonarcloud_project_properties sonarcloud_project_properties_pa
     foreach(source_file ${source_source_files})
       list(REMOVE_ITEM test_files ${source_file})
     endforeach()
+
+    # Exclude any headers in sub-directories of test folder from coverage reporting
+    foreach(test_file ${test_files})
+      get_filename_component(test_directory "${test_file}" DIRECTORY)
+      set(test_files ${test_files} "${test_directory}/*.h")
+    endforeach()
+    list(REMOVE_DUPLICATES test_files)
+
     list(JOIN test_files ",${_sonarcloud_newline}" sonar_test_files)
     string(APPEND sonarcloud_project_properties_content "sonar.coverage.exclusions=${_sonarcloud_newline}${sonar_test_files}\n")
   endif()


### PR DESCRIPTION
## Background
In a [recent PR](https://github.com/swift-nav/orion-engine/pull/5460) the code coverage stage failed because there was a header file defined as part of unit tests, which wasn't ignored when tracking code coverage on Sonarcloud.
We already [exclude unit test source](https://github.com/swift-nav/cmake/blob/6a21068169993b0665941062d08d76c66ab08f26/Sonarcloud.cmake#L228-L228) files from code coverage, but not header files.

## Changes
Before setting the exclusions:
- For each unit test source file
  - Extract the directory it is in
  - Add `<directory>/*.h` to the test files list
- Remove duplicates from the test files list, as there would otherwise be one identical entry in the test files list for each source file in a directory.

## Testing
- Inspected the generated `sonar-project.properties` file, which now has `*.h` for each directory containing unit test source files.
- Pointed the cmake submodule pointer in the PR in question to this branch, and the coverage report for the header file on Sonarcloud has gone away.