### PR TITLE
Remove pvt-runner-lib from search libraries in starling target [AGNSS-17]

### DIFF
--- a/FindStarling.cmake
+++ b/FindStarling.cmake
@@ -17,19 +17,17 @@ option(starling_ENABLE_TEST_LIBS "" OFF)
 option(starling_ENABLE_EXAMPLES "" OFF)
 
 GenericFindDependency(
-  TARGET pvt-runner-lib
+  TARGET pvt-engine
   ADDITIONAL_TARGETS
     math_routines
     sensorfusion
     pvt_driver
     pvt-common
     pvt-engine
-    pvt-runner
     pvt-sbp-logging
     pvt-sizes
     pvt-version
     starling-build-config
     starling-util
   SOURCE_DIR starling
-  SYSTEM_HEADER_FILE "pvt_driver/runner/pvt_runner.h"
 )


### PR DESCRIPTION
`pvt-runner-lib` target removed from starling repo, but is still referenced by this find module. Remove the reference. Tested upstream to fix cmake configure failure in orion-engine