### PR TITLE
Turn off duplicate detection in SonarCloud for test targets [SEN-798]

### DIFF
--- a/Sonarcloud.cmake
+++ b/Sonarcloud.cmake
@@ -226,6 +226,7 @@ function(generate_sonarcloud_project_properties sonarcloud_project_properties_pa
 
     list(JOIN test_files ",${_sonarcloud_newline}" sonar_test_files)
     string(APPEND sonarcloud_project_properties_content "sonar.coverage.exclusions=${_sonarcloud_newline}${sonar_test_files}\n")
+    string(APPEND sonarcloud_project_properties_content "sonar.cpd.exclusions=${_sonarcloud_newline}${sonar_test_files}\n")
   endif()
 
   file(GENERATE


### PR DESCRIPTION
Turning off code duplication warnings for test targets. Tested in Starling here: https://github.com/swift-nav/starling/pull/7760

This has been getting into our way a lot, since we want to make most tests [DAMP rather than DRY](https://testing.googleblog.com/2019/12/testing-on-toilet-tests-too-dry-make.html).