### PR TITLE
Add TEST_SRCS property and swift_add_test_srcs_target macro [BUILD-657]

### DIFF
--- a/TestTargets.cmake
+++ b/TestTargets.cmake
@@ -411,3 +411,13 @@ function(swift_add_test target)
   endforeach()
 
 endfunction()
+
+macro(swift_add_test_srcs_target)
+  get_property(test_srcs GLOBAL PROPERTY TEST_SRCS)
+
+  string (REPLACE ";" "\\n" test_srcs_str "${test_srcs}")
+
+  add_custom_target(test_srcs
+    COMMAND echo "'${test_srcs_str}'" | tail -n +2 | sort > cmake_test_srcs.txt
+  )
+endmacro()

--- a/TestTargets.cmake
+++ b/TestTargets.cmake
@@ -397,4 +397,17 @@ function(swift_add_test target)
     add_dependencies(build-post-build-tests ${target})
     add_dependencies(post-build-${target} build-post-build-tests)
   endif()
+
+  foreach(src ${x_SRCS})
+    get_filename_component(absolute_src ${src} ABSOLUTE)
+    if(${absolute_src} MATCHES "${CMAKE_BINARY_DIR}.*")
+      continue()
+    endif()
+    string(REPLACE ${PROJECT_SOURCE_DIR}/ "" relative_src ${absolute_src})
+
+    set_property(GLOBAL
+      APPEND_STRING
+      PROPERTY TEST_SRCS "\\n${relative_src}")
+  endforeach()
+
 endfunction()


### PR DESCRIPTION
This PR adds:
- the `TEST_SRCS` global property, which stores all test source files,
- the `swift_add_test_srcs_target` macro, which adds the `test_srcs` target, which creates the `cmake_test_srcs.txt` that contains all test source files. 

# Testing 

https://github.com/swift-nav/starling/pull/7881