### PR TITLE
[ASILSAFE-150] Upgrade warnings to errors option in clang tidy generator

### DIFF
--- a/ClangTidy.cmake
+++ b/ClangTidy.cmake
@@ -112,7 +112,7 @@ function(swift_create_clang_tidy_targets)
     return()
   endif()
 
-  set(argOption "DONT_GENERATE_CLANG_TIDY_CONFIG" "WITHOUT_SWIFT_TYPES")
+  set(argOption "DONT_GENERATE_CLANG_TIDY_CONFIG" "WITHOUT_SWIFT_TYPES" "WARNINGS_AS_ERRORS")
   set(argSingle "")
   set(argMulti "FLAGS_TO_ENABLE")
 
@@ -280,6 +280,12 @@ Checks: \"${comma_checks}\"
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: true
 ")
+
+    if (x_WARNINGS_AS_ERRORS)
+      file(APPEND ${CMAKE_SOURCE_DIR}/.clang-tidy "\
+WarningsAsErrors: '*'
+")
+    endif ()
   endif()
 
   # These two lists will ultimately contain the complete set of source files to pass to the clang-tidy-all and clang-tidy-world targets


### PR DESCRIPTION
## Changes

For ASIL projects, we want to upgrade all clang-tidy warnings to errors. The clang-tidy setup in `orion-engine` is useless and doesn't flag anything. This work allows us to upgrade the checks in orion when needed.