### PR TITLE
Fix TEST_SRCS property - use CMAKE_SOURCE_DIR

### DIFF
--- a/TestTargets.cmake
+++ b/TestTargets.cmake
@@ -403,7 +403,7 @@ function(swift_add_test target)
     if(${absolute_src} MATCHES "${CMAKE_BINARY_DIR}.*")
       continue()
     endif()
-    string(REPLACE ${PROJECT_SOURCE_DIR}/ "" relative_src ${absolute_src})
+    string(REPLACE ${CMAKE_SOURCE_DIR}/ "" relative_src ${absolute_src})
 
     set_property(GLOBAL
       APPEND_STRING


### PR DESCRIPTION
Let's use `CMAKE_SOURCE_DIR` instead of `PROJECT_SOURCE_DIR` in order to use the top-level `CMakeLists` path instead of the current project path.