### PR TITLE
fix: make test_srcs target project specific [BUILD-694]

### DIFF
--- a/TestTargets.cmake
+++ b/TestTargets.cmake
@@ -416,8 +416,7 @@ macro(swift_add_test_srcs_target)
   get_property(test_srcs GLOBAL PROPERTY TEST_SRCS)
 
   string (REPLACE ";" "\\n" test_srcs_str "${test_srcs}")
-
-  add_custom_target(test_srcs
+  add_custom_target(${PROJECT_NAME}_test_srcs
     COMMAND echo "'${test_srcs_str}'" | tail -n +2 | sort > cmake_test_srcs.txt
   )
 endmacro()


### PR DESCRIPTION
This fixes a duplicate target being defined when enabling the test suite of a projects submodule