### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@swift-nav/devinfra


### PR DESCRIPTION
Enables developer infrastructure to be aware of any development going on in the cmake repo.

Particularly we want to avoid new features being developed for cmake that are not accounted for in the bazel system.