### PR TITLE
Enable starling-core test libs [AP-454]

### DIFF
--- a/FindStarlingCore.cmake
+++ b/FindStarlingCore.cmake
@@ -13,7 +13,7 @@
 include("GenericFindDependency")
 
 option(starling-core_ENABLE_TESTS "" OFF)
-option(starling-core_ENABLE_TEST_LIBS "" OFF)
+option(starling-core_ENABLE_TEST_LIBS "" ON)
 
 GenericFindDependency(
   TARGET internal-utils


### PR DESCRIPTION
Turn on test libraries in starling-core by default