### PR TITLE
Add iec559 check

### DIFF
--- a/CheckIec559.cmake
+++ b/CheckIec559.cmake
@@ -12,4 +12,3 @@ function(check_cxx_double_is_iec559)
     message(FATAL_ERROR "Compiler does not support IEC 559 (IEEE 754) doubles.")
   endif()
 endfunction()
-

--- a/CheckIec559.cmake
+++ b/CheckIec559.cmake
@@ -1,0 +1,15 @@
+include(CheckCXXSourceCompiles)
+
+function(check_cxx_double_is_iec559)
+  check_cxx_source_compiles("#include <limits>
+  int main() {
+    return std::numeric_limits<double>::is_iec559 ? 1 : 0;
+  }" IEC559_DOUBLE_SUPPORTED)
+
+  if(IEC559_DOUBLE_SUPPORTED)
+    message(STATUS "Compiler supports IEC 559 (IEEE 754) doubles.")
+  else()
+    message(FATAL_ERROR "Compiler does not support IEC 559 (IEEE 754) doubles.")
+  endif()
+endfunction()
+


### PR DESCRIPTION
# Rationale

We need to check double type definition for ASIL purposes. This adds a simple check, then called by integrity_core_common (or any library needing to check double definition)

# Related PRs
https://github.com/swift-nav/rules_swiftnav/pull/115
https://github.com/swift-nav/orion-engine/pull/7226