### PR TITLE
ASIO C++ and ASIO Grpc libraries

### DIFF
--- a/FindAsio.cmake
+++ b/FindAsio.cmake
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+
+if(TARGET asio::asio)
+  return()
+endif()
+
+add_library(asio_asio INTERFACE)
+add_library(asio::asio ALIAS asio_asio)
+
+target_include_directories(asio_asio
+  SYSTEM INTERFACE
+    ${PROJECT_SOURCE_DIR}/third_party/asio/asio/include
+)

--- a/FindAsioGrpc.cmake
+++ b/FindAsioGrpc.cmake
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+
+include("GenericFindDependency")
+
+GenericFindDependency(
+  TARGET asio-grpc::asio-grpc-standalone-asio
+  SOURCE_DIR asio-grpc
+  SYSTEM_INCLUDES
+)


### PR DESCRIPTION
# Changes

Introduced the ability to include [ASIO C++](https://think-async.com/Asio/) as well as [ASIO gRPC](https://github.com/Tradias/asio-grpc) third party libraries.

# Related

Similar implementation with bazel https://github.com/swift-nav/rules_swiftnav/pull/127
