### PR TITLE
Add FindOrion module

### DIFF
--- a/FindOrion.cmake
+++ b/FindOrion.cmake
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2024 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+
+include("GenericFindDependency")
+
+set(orion_ENABLE_CLANG_FORMAT ON)
+
+GenericFindDependency(
+  TARGET orion
+  SOURCE_DIR orion
+)


### PR DESCRIPTION
- Adds FindOrion.cmake and hopes no one else needs to use it :skull: 
- We are working on some load testing scripts which may need access to some of the rpc code in orion for mocking purposes.