### PR TITLE
orion cmake configuration fails when CMAKE_C_COMPILED_ID is not set [OI-1869]

### DIFF
--- a/LanguageStandards.cmake
+++ b/LanguageStandards.cmake
@@ -60,7 +60,7 @@ function(swift_set_language_standards)
     set(C_EXTENSIONS OFF)
   endif()
 
-  if(${CMAKE_C_COMPILER_ID} STREQUAL "IAR")
+  if(CMAKE_C_COMPILER_ID STREQUAL "IAR")
     set_target_properties(${x_UNPARSED_ARGUMENTS}
       PROPERTIES
       C_STANDARD_REQUIRED ON


### PR DESCRIPTION
## Jira Ticket

https://swift-nav.atlassian.net/browse/OI-1869

## Bug description

orion build fails with

```bash
CMake Error at third_party/orion-engine/third_party/auk/cmake/swift_nav/LanguageStandards.cmake:63 (if):
  if given arguments:

    "STREQUAL" "IAR"

  Unknown arguments specified
Call Stack (most recent call first):
  third_party/orion-engine/third_party/auk/cmake/swift_nav/SwiftTargets.cmake:351 (swift_set_language_standards)
  third_party/orion-engine/third_party/auk/cmake/swift_nav/SwiftTargets.cmake:373 (swift_add_target)
  proto/CMakeLists.txt:29 (swift_add_library)
```

CMake syntax allows using the variable without ${} to simultaneously check if variable is defined, and variable content.


## Testing

Updated `third_party/orion-engine/third_party/auk/cmake/swift_nav/LanguageStandards.cmake` locally with the fix, CMake config runs correctly.


