### PR TITLE
Static bundles for the IAR toolchain[DRAFT]

### DIFF
--- a/ArchiveUtility.cmake
+++ b/ArchiveUtility.cmake
@@ -129,26 +129,6 @@ function (add_static_library_bundle target)
   string (APPEND mri_script "echo save\n")
   string (APPEND mri_script "echo end\n")
 
-  if (NOT ARCHIVE_IAR)
-    set (mri_script_file ${mri_script_dir}/script.mri.sh)
-
-    file (GENERATE
-      OUTPUT ${mri_script_file}
-      CONTENT "${mri_script}"
-      CONDITION 1
-    )
-
-    add_custom_command (
-      OUTPUT ${output_directory}/${output_library}
-      COMMAND bash ${mri_script_file} | ${CMAKE_AR} -M
-      COMMAND_EXPAND_LISTS
-      WORKING_DIRECTORY
-        ${output_directory}
-      DEPENDS
-        ${bundle_libraries}
-    )
-  endif()
-
   if (ARCHIVE_IAR)
     set (iar_script)
     string (APPEND iar_script "--create")
@@ -169,6 +149,24 @@ function (add_static_library_bundle target)
     add_custom_command (
       OUTPUT ${output_directory}/${output_library}
       COMMAND ${CMAKE_AR} -f ${iar_script_file}
+      COMMAND_EXPAND_LISTS
+      WORKING_DIRECTORY
+        ${output_directory}
+      DEPENDS
+        ${bundle_libraries}
+    )
+  else ()
+    set (mri_script_file ${mri_script_dir}/script.mri.sh)
+
+    file (GENERATE
+      OUTPUT ${mri_script_file}
+      CONTENT "${mri_script}"
+      CONDITION 1
+    )
+
+    add_custom_command (
+      OUTPUT ${output_directory}/${output_library}
+      COMMAND bash ${mri_script_file} | ${CMAKE_AR} -M
       COMMAND_EXPAND_LISTS
       WORKING_DIRECTORY
         ${output_directory}

--- a/ArchiveUtility.cmake
+++ b/ArchiveUtility.cmake
@@ -127,25 +127,52 @@ function (add_static_library_bundle target)
     string (APPEND mri_script "fi\n\n")
   endforeach()
   string (APPEND mri_script "echo save\n")
-  string (APPEND mri_script "echo end")
+  string (APPEND mri_script "echo end\n")
 
-  set (mri_script_file ${mri_script_dir}/script.mri.sh)
+  set (iar_script)
+  string (APPEND iar_script "--create")
+  foreach (bundle_library IN LISTS bundle_libraries)
+    string (APPEND iar_script " \$<TARGET_FILE:${bundle_library}>")
+  endforeach()
+  string (APPEND iar_script " -o ${output_directory}/${output_library}\n")
+
+  set (iar_script_file ${mri_script_dir}/script.iar.sh)
+  set (iar_cp_file ${mri_script_dir}/script.iar_cp.sh)
 
   file (GENERATE
-    OUTPUT ${mri_script_file}
-    CONTENT "${mri_script}"
+    OUTPUT ${iar_script_file}
+    CONTENT "${iar_script}"
     CONDITION 1
   )
 
+
   add_custom_command (
     OUTPUT ${output_directory}/${output_library}
-    COMMAND bash ${mri_script_file} | ${CMAKE_AR} -M
+    COMMAND ${CMAKE_AR} -f ${iar_script_file}
     COMMAND_EXPAND_LISTS
     WORKING_DIRECTORY
       ${output_directory}
     DEPENDS
       ${bundle_libraries}
   )
+
+  # set (mri_script_file ${mri_script_dir}/script.mri.sh)
+
+  # file (GENERATE
+  #   OUTPUT ${mri_script_file}
+  #   CONTENT "${mri_script}"
+  #   CONDITION 1
+  # )
+
+  # add_custom_command (
+  #   OUTPUT ${output_directory}/${output_library}
+  #   COMMAND bash ${mri_script_file} | ${CMAKE_AR} -M
+  #   COMMAND_EXPAND_LISTS
+  #   WORKING_DIRECTORY
+  #     ${output_directory}
+  #   DEPENDS
+  #     ${bundle_libraries}
+  # )
 
   add_custom_target (${target} ALL
     DEPENDS ${output_directory}/${output_library}

--- a/ArchiveUtility.cmake
+++ b/ArchiveUtility.cmake
@@ -129,50 +129,53 @@ function (add_static_library_bundle target)
   string (APPEND mri_script "echo save\n")
   string (APPEND mri_script "echo end\n")
 
-  set (iar_script)
-  string (APPEND iar_script "--create")
-  foreach (bundle_library IN LISTS bundle_libraries)
-    string (APPEND iar_script " \$<TARGET_FILE:${bundle_library}>")
-  endforeach()
-  string (APPEND iar_script " -o ${output_directory}/${output_library}\n")
+  if (NOT ARCHIVE_IAR)
+    set (mri_script_file ${mri_script_dir}/script.mri.sh)
 
-  set (iar_script_file ${mri_script_dir}/script.iar.sh)
-  set (iar_cp_file ${mri_script_dir}/script.iar_cp.sh)
+    file (GENERATE
+      OUTPUT ${mri_script_file}
+      CONTENT "${mri_script}"
+      CONDITION 1
+    )
 
-  file (GENERATE
-    OUTPUT ${iar_script_file}
-    CONTENT "${iar_script}"
-    CONDITION 1
-  )
+    add_custom_command (
+      OUTPUT ${output_directory}/${output_library}
+      COMMAND bash ${mri_script_file} | ${CMAKE_AR} -M
+      COMMAND_EXPAND_LISTS
+      WORKING_DIRECTORY
+        ${output_directory}
+      DEPENDS
+        ${bundle_libraries}
+    )
+  endif()
 
+  if (ARCHIVE_IAR)
+    set (iar_script)
+    string (APPEND iar_script "--create")
+    foreach (bundle_library IN LISTS bundle_libraries)
+      string (APPEND iar_script " \$<TARGET_FILE:${bundle_library}>")
+    endforeach()
+    string (APPEND iar_script " -o ${output_directory}/${output_library}\n")
 
-  add_custom_command (
-    OUTPUT ${output_directory}/${output_library}
-    COMMAND ${CMAKE_AR} -f ${iar_script_file}
-    COMMAND_EXPAND_LISTS
-    WORKING_DIRECTORY
-      ${output_directory}
-    DEPENDS
-      ${bundle_libraries}
-  )
+    set (iar_script_file ${mri_script_dir}/script.iar.sh)
+    set (iar_cp_file ${mri_script_dir}/script.iar_cp.sh)
 
-  # set (mri_script_file ${mri_script_dir}/script.mri.sh)
+    file (GENERATE
+      OUTPUT ${iar_script_file}
+      CONTENT "${iar_script}"
+      CONDITION 1
+    )
 
-  # file (GENERATE
-  #   OUTPUT ${mri_script_file}
-  #   CONTENT "${mri_script}"
-  #   CONDITION 1
-  # )
-
-  # add_custom_command (
-  #   OUTPUT ${output_directory}/${output_library}
-  #   COMMAND bash ${mri_script_file} | ${CMAKE_AR} -M
-  #   COMMAND_EXPAND_LISTS
-  #   WORKING_DIRECTORY
-  #     ${output_directory}
-  #   DEPENDS
-  #     ${bundle_libraries}
-  # )
+    add_custom_command (
+      OUTPUT ${output_directory}/${output_library}
+      COMMAND ${CMAKE_AR} -f ${iar_script_file}
+      COMMAND_EXPAND_LISTS
+      WORKING_DIRECTORY
+        ${output_directory}
+      DEPENDS
+        ${bundle_libraries}
+    )
+  endif()
 
   add_custom_target (${target} ALL
     DEPENDS ${output_directory}/${output_library}


### PR DESCRIPTION
We made a release to Asensing but the IAR library was not bundled properly and static linking was not done.
The plan is to use `add_static_library_bundle` but,  the archive code is not compatible with IAR.

A flag was added that is only set during IAR compilation and installs.

Currently, we are using CMAKE but plan to move to Bazel after this patch release