### PR TITLE
Fix importing of latest protobuf version

### DIFF
--- a/FindGrpc.cmake
+++ b/FindGrpc.cmake
@@ -1,6 +1,8 @@
 include("GenericFindDependency")
 
 option(ABSL_PROPAGATE_CXX_STD "Use CMake C++ standard meta features (e.g. cxx_std_11) that propagate to targets that link to Abseil" true)
+option(protobuf_INSTALL "Install protobuf binaries and files" OFF)
+option(utf8_range_ENABLE_INSTALL "Configure installation" OFF)
 
 GenericFindDependency(
   TARGET grpc++

--- a/FindProtobuf.cmake
+++ b/FindProtobuf.cmake
@@ -10,6 +10,9 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 #
 
+option (protobuf_INSTALL "Install protobuf binaries and files" OFF)
+option (utf8_range_ENABLE_INSTALL "Configure installation" OFF)
+
 include("GenericFindDependency")
 option(protocol_BUILD_TESTS "" OFF)
 GenericFindDependency(

--- a/FindProtobuf.cmake
+++ b/FindProtobuf.cmake
@@ -10,8 +10,8 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 #
 
-option (protobuf_INSTALL "Install protobuf binaries and files" OFF)
-option (utf8_range_ENABLE_INSTALL "Configure installation" OFF)
+option(protobuf_INSTALL "Install protobuf binaries and files" OFF)
+option(utf8_range_ENABLE_INSTALL "Configure installation" OFF)
 
 include("GenericFindDependency")
 option(protocol_BUILD_TESTS "" OFF)


### PR DESCRIPTION
# Changes

In order to use the latest protobuf `v5.29.0` version, we need to tweek some compile options to remove the installation commands from a few targets, otherwise you will get the following errors:

```
-- Performing Test HAVE_CXX_FLAG_WNO_VARIADIC_MACROS
-- Performing Test HAVE_CXX_FLAG_WNO_VARIADIC_MACROS - Success
-- Configuring done (139.2s)
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_absl_check" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_absl_log" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_algorithm" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_base" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_bind_front" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_bits" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_btree" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_cleanup" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_cord" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_core_headers" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_debugging" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_die_if_null" that is not in any export set.
CMake Error: install(EXPORT "protobuf-targets" ...) includes target "libprotobuf-lite" which requires target "absl_dynamic_annotations" that is not in any export set.
...
```