### PR TITLE
Adapt FindNanopb.cmake to allow the usage of the official sources

### DIFF
--- a/FindNanopb.cmake
+++ b/FindNanopb.cmake
@@ -12,8 +12,40 @@
 
 include("GenericFindDependency")
 option(nanopb_BUILD_GENERATOR "" OFF)
-GenericFindDependency(
-  TARGET protobuf-nanopb
-  SOURCE_DIR "nanopb"
-  SYSTEM_INCLUDES
-)
+
+if(USE_OFFICIAL_NANOPB)
+  # Using official Nanopb from github and therefore manually including FindNanopb.cmake
+  GenericFindDependency(
+    TARGET protobuf-nanopb-static
+    SOURCE_DIR "nanopb"
+    SYSTEM_INCLUDES
+  )
+
+  # Instead of patches to the official Nanopb, we need to make all the adaptions here
+  include("${nanopb_SOURCE_DIR}/extra/FindNanopb.cmake")
+  target_include_directories(
+    protobuf-nanopb-static
+    PUBLIC
+      $<BUILD_INTERFACE:${nanopb_SOURCE_DIR}>
+  )
+  # without this, the compilations fails due to C99 asserts
+  target_compile_definitions(
+    protobuf-nanopb-static
+    PUBLIC
+      PB_NO_STATIC_ASSERT
+  )
+  # This is needed to avoid warnings about switch statements on enum types
+  target_compile_options(
+    protobuf-nanopb-static
+    PUBLIC
+      -Wno-switch-enum
+  )
+  # This is how the lib is used
+  add_library(protobuf-nanopb ALIAS protobuf-nanopb-static)
+else()
+  GenericFindDependency(
+    TARGET protobuf-nanopb
+    SOURCE_DIR "nanopb"
+    SYSTEM_INCLUDES
+  )
+endif()


### PR DESCRIPTION
# Changes

This change is needed to use nanopb from the [official github repo](https://github.com/nanopb/nanopb). starling's Bazel build is already using the official repo, hence the harmonization to use the same sources.

Backwards compatibility is kept.

# Jira
[AP-3745](https://swift-nav.atlassian.net/browse/AP-3745)


[AP-3745]: https://swift-nav.atlassian.net/browse/AP-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ