### PR TITLE
Add option for suppression file in valgrind memcheck [AP-3695]

### DIFF
--- a/Valgrind.cmake
+++ b/Valgrind.cmake
@@ -294,7 +294,7 @@ endmacro()
 
 function(swift_add_valgrind_memcheck target)
   set(argOption SHOW_REACHABLE TRACK_ORIGINS UNDEF_VALUE_ERRORS GENERATE_JUNIT_REPORT)
-  set(argSingle LEAK_CHECK)
+  set(argSingle LEAK_CHECK SUPPRESSIONS_FILE)
   set(argMulti JUNIT_OPTIONS)
 
   set(valgrind_tool memcheck)


### PR DESCRIPTION
Valgrind memcheck supports suppression files. This change allows using our cmake logic to specify a suppression file relative to the repo root.

Tested: https://github.com/swift-nav/starling/pull/9972