### PR TITLE
Fix compiler errors from check third-party dependency on Windows

### DIFF
--- a/FindCheck.cmake
+++ b/FindCheck.cmake
@@ -17,3 +17,14 @@ GenericFindDependency(
   TARGET check
   SYSTEM_INCLUDES
 )
+
+# Disable warnings-as-errors for check library since it's a third-party dependency
+# and its source files are compiled directly (not just headers), so SYSTEM_INCLUDES
+# doesn't suppress warnings. This prevents issues like implicit function declarations
+# on Windows (e.g., alarm() in timer_delete.c) from breaking the build.
+if(TARGET check)
+  target_compile_options(check PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error>)
+endif()
+if(TARGET checkShared)
+  target_compile_options(checkShared PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error>)
+endif()

--- a/FindCheck.cmake
+++ b/FindCheck.cmake
@@ -18,10 +18,17 @@ option(CHECK_INSTALL "" OFF)
 set(_SAVED_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 
 # Temporarily modify CMAKE_C_FLAGS to disable implicit-function-declaration errors
-# for the check library compilation (needed for Windows/MinGW compatibility)
+# for the check library compilation (needed for Windows compatibility)
 if(WIN32)
-  string(REPLACE "-Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=implicit-function-declaration")
+  if(MSVC)
+    # MSVC: Remove warnings-as-errors flag and disable specific warning C4013 (implicit function declaration)
+    string(REPLACE "/WX" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4013")
+  else()
+    # MinGW/GCC: Remove -Werror and disable implicit-function-declaration errors
+    string(REPLACE "-Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=implicit-function-declaration")
+  endif()
 endif()
 
 GenericFindDependency(


### PR DESCRIPTION
# Issue

The check unit testing framework (used as a third-party dependency) emits compiler diagnostics that break the build on Windows platforms, even though it's configured as an external dependency with `SYSTEM_INCLUDES`.

Specific error:
``` 
D:\a\libsbp\libsbp\c\third_party\check\lib\timer_delete.c:48:5: error: implicit declaration of function 'alarm' [-Wimplicit-function-declaration]
```

# Root Cause

The check library has platform compatibility issues on Windows:

1. Missing POSIX functions: Windows lacks POSIX functions like alarm(), setitimer(), and proper timer support
2. Incomplete fallback detection: While check includes compatibility shims (e.g., alarm.c), the file timer_delete.c calls alarm() directly without proper header inclusion or declaration checking
3. SYSTEM_INCLUDES limitation: The SYSTEM_INCLUDES flag in CMake only suppresses warnings from headers consumed via target_include_directories(). However, check adds its compatibility source files (including timer_delete.c) directly to the target via target_sources(), so these files are compiled as part of the target itself and inherit all parent compile flags including -Werror

Note: The check project has been unmaintained for over 4 years (last release: 0.15.2 in 2020), making an upstream fix unlikely.

# Solution

Modified cmake/common/FindCheck.cmake to temporarily adjust CMAKE_C_FLAGS during the check library's configuration and compilation:

1. Save original flags before including the dependency
2. Apply platform-specific suppressions:
  - MinGW/GCC: Remove -Werror and add -Wno-error=implicit-function-declaration
  - MSVC: Remove /WX and add /wd4013 (disables C4013: implicit function declaration)
3. Restore original flags immediately after the dependency is added

This approach:
 - ✅ Doesn't modify third-party code
 - ✅ Only affects check library compilation
 - ✅ Preserves strict warnings for project code
 - ✅ Supports both MinGW and MSVC toolchains
